### PR TITLE
Allow custom driver paths

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,0 +1,8 @@
+import os
+
+# Default base directory (update as needed)
+BASE_DIR = r"C:\\Users\\Lamine\\Desktop\\woocommerce\\code\\CODE POUR BOB"
+
+# Default paths for Chrome driver and binary
+CHROME_DRIVER_PATH = os.path.join(BASE_DIR, r"../chromdrivers 137/chromedriver-win64/chromedriver.exe")
+CHROME_BINARY_PATH = os.path.join(BASE_DIR, r"../chromdrivers 137/chrome-win64/chrome.exe")

--- a/main.py
+++ b/main.py
@@ -18,6 +18,7 @@ from PySide6.QtWidgets import (
     QVBoxLayout,
     QWidget,
 )
+import config
 
 
 class ConsoleOutput(QObject):
@@ -211,8 +212,26 @@ class MainWindow(QMainWindow):
     def _create_settings_page(self):
         page = QWidget()
         layout = QVBoxLayout(page)
-        layout.setAlignment(Qt.AlignCenter)
-        layout.addWidget(QLabel("Param\u00e8tres"))
+        layout.setAlignment(Qt.AlignTop)
+
+        layout.addWidget(QLabel("Chemin du chromedriver"))
+        driver_layout = QHBoxLayout()
+        self.input_driver_path = QLineEdit(config.CHROME_DRIVER_PATH)
+        btn_driver = QPushButton("Parcourir")
+        btn_driver.clicked.connect(self._choose_driver_path)
+        driver_layout.addWidget(self.input_driver_path)
+        driver_layout.addWidget(btn_driver)
+        layout.addLayout(driver_layout)
+
+        layout.addWidget(QLabel("Chemin du navigateur Chrome"))
+        binary_layout = QHBoxLayout()
+        self.input_binary_path = QLineEdit(config.CHROME_BINARY_PATH)
+        btn_binary = QPushButton("Parcourir")
+        btn_binary.clicked.connect(self._choose_binary_path)
+        binary_layout.addWidget(self.input_binary_path)
+        binary_layout.addWidget(btn_binary)
+        layout.addLayout(binary_layout)
+
         return page
 
     # --- Logic placeholders ---------------------------------------------
@@ -247,6 +266,16 @@ class MainWindow(QMainWindow):
         folder = QFileDialog.getExistingDirectory(self, "Choisir le dossier des fiches")
         if folder:
             self.input_fiche_folder.setText(folder)
+
+    def _choose_driver_path(self):
+        path, _ = QFileDialog.getOpenFileName(self, "Choisir chromedriver")
+        if path:
+            self.input_driver_path.setText(path)
+
+    def _choose_binary_path(self):
+        path, _ = QFileDialog.getOpenFileName(self, "Choisir le binaire Chrome")
+        if path:
+            self.input_binary_path.setText(path)
 
 
 if __name__ == "__main__":

--- a/scraper_woocommerce.py
+++ b/scraper_woocommerce.py
@@ -6,15 +6,16 @@ from bs4 import BeautifulSoup
 import unicodedata
 import time, random
 import requests
+import config
 
 from selenium import webdriver
 from selenium.webdriver.chrome.service import Service
 from selenium.webdriver.common.by import By
 
 # === CONFIGURATION ===
-base_dir = r"C:\Users\Lamine\Desktop\woocommerce\code\CODE POUR BOB"
-chrome_driver_path = os.path.join(base_dir, r"../chromdrivers 137/chromedriver-win64/chromedriver.exe")
-chrome_binary_path = os.path.join(base_dir, r"../chromdrivers 137/chrome-win64/chrome.exe")
+base_dir = config.BASE_DIR
+chrome_driver_path = config.CHROME_DRIVER_PATH
+chrome_binary_path = config.CHROME_BINARY_PATH
 
 fiche_dir = os.path.join(base_dir, "optimisation_fiches")
 liens_id_txt = os.path.join(base_dir, "liens_avec_id.txt")
@@ -62,14 +63,16 @@ def charger_liste_ids():
     return ids
 
 # === SCRAPING PRODUITS (VARIANTES) ===
-def scrap_produits_par_ids(id_url_map, ids_selectionnes):
+def scrap_produits_par_ids(id_url_map, ids_selectionnes, driver_path=None, binary_path=None):
+    driver_path = driver_path or config.CHROME_DRIVER_PATH
+    binary_path = binary_path or config.CHROME_BINARY_PATH
     options = webdriver.ChromeOptions()
-    options.binary_location = chrome_binary_path
+    options.binary_location = binary_path
     options.add_argument("--headless")
     options.add_argument('--disable-blink-features=AutomationControlled')
     options.add_experimental_option("excludeSwitches", ["enable-automation"])
     options.add_experimental_option('useAutomationExtension', False)
-    service = Service(executable_path=chrome_driver_path)
+    service = Service(executable_path=driver_path)
     driver = webdriver.Chrome(service=service, options=options)
     driver.execute_cdp_cmd("Page.addScriptToEvaluateOnNewDocument", {
         "source": "Object.defineProperty(navigator, 'webdriver', {get: () => undefined})"
@@ -175,10 +178,12 @@ def scrap_produits_par_ids(id_url_map, ids_selectionnes):
     return n_ok, n_err
 
 # === SCRAPING FICHES CONCURRENTS ===
-def scrap_fiches_concurrents(id_url_map, ids_selectionnes):
-    service = Service(executable_path=chrome_driver_path)
+def scrap_fiches_concurrents(id_url_map, ids_selectionnes, driver_path=None, binary_path=None):
+    driver_path = driver_path or config.CHROME_DRIVER_PATH
+    binary_path = binary_path or config.CHROME_BINARY_PATH
+    service = Service(executable_path=driver_path)
     options = webdriver.ChromeOptions()
-    options.binary_location = chrome_binary_path
+    options.binary_location = binary_path
     options.add_experimental_option("excludeSwitches", ["enable-automation"])
     options.add_experimental_option('useAutomationExtension', False)
     options.add_argument("--disable-blink-features=AutomationControlled")
@@ -366,9 +371,9 @@ if __name__ == "__main__":
 
         actions = []
         if var_variantes.get():
-            actions.append(lambda: scrap_produits_par_ids(id_url_map, ids))
+            actions.append(lambda: scrap_produits_par_ids(id_url_map, ids, chrome_driver_path, chrome_binary_path))
         if var_concurrents.get():
-            actions.append(lambda: scrap_fiches_concurrents(id_url_map, ids))
+            actions.append(lambda: scrap_fiches_concurrents(id_url_map, ids, chrome_driver_path, chrome_binary_path))
         if var_json.get():
             actions.append(export_fiches_concurrents_json)
 


### PR DESCRIPTION
## Summary
- create `config.py` with chrome driver defaults
- use configurable driver paths in scraping functions
- add driver path fields to PySide6 UI

## Testing
- `python -m py_compile scraper_woocommerce.py main.py config.py flask_server.py`

------
https://chatgpt.com/codex/tasks/task_e_68402e41402c83308a385345e5750ee7