### PR TITLE
Improve scraper folder selection

### DIFF
--- a/scraper_woocommerce.py
+++ b/scraper_woocommerce.py
@@ -91,7 +91,15 @@ class ScraperCore:
 
     # --- Runtime configuration ------------------------------------------
     def prepare_results_dir(self, selected_base, result_name):
-        self.results_dir = os.path.join(selected_base, result_name)
+        base_path = os.path.join(selected_base, result_name)
+        final_path = base_path
+        if os.path.exists(final_path):
+            idx = 2
+            while os.path.exists(f"{base_path}_{idx}"):
+                idx += 1
+            final_path = f"{base_path}_{idx}"
+
+        self.results_dir = final_path
         descriptions_dir = os.path.join(self.results_dir, "descriptions")
         self.json_dir = os.path.join(self.results_dir, "json")
         xlsx_dir = os.path.join(self.results_dir, "xlsx")


### PR DESCRIPTION
## Summary
- enhance scraper page with parent folder and result folder name fields
- show computed result path live
- adjust scraper startup to use new fields
- auto-create folders with numeric suffix if needed

## Testing
- `python -m py_compile main.py scraper_woocommerce.py flask_server.py`

------
https://chatgpt.com/codex/tasks/task_e_68409031aa2883308e46f49318fc484c