### PR TITLE
Skip unsupported files in optimizer

### DIFF
--- a/optimizer.py
+++ b/optimizer.py
@@ -42,8 +42,12 @@ class ImageOptimizer:
         logs = []
         for root, _, files in os.walk(folder):
             for f in files:
-                path = os.path.join(root, f)
-                logs.append(self.optimize_file(path))
+                ext = os.path.splitext(f)[1].lower()
+                if ext in [".png", ".webp"] or (
+                    self.jpegoptim_path and ext in [".jpg", ".jpeg"]
+                ):
+                    path = os.path.join(root, f)
+                    logs.append(self.optimize_file(path))
         return logs
 
 # EXEMPLE D'UTILISATION :


### PR DESCRIPTION
## Summary
- only run optimizers for PNG, WebP and optionally JPEG files

## Testing
- `python -m py_compile *.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840b84668348330a34f90797216f05c