### PR TITLE
Add optimizer path configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ Use the "Mode sans t\u00eate (headless)" checkbox in the settings page to run Ch
 ## Image Optimization Tools
 The project includes an optional image optimizer. Before using this feature,
 download `optipng.exe` and `cwebp.exe` and place them inside the
-`tools/optimizers/` directory at the root of the repository:
+`tools/optimizers/` directory at the root of the repository (or set their
+locations in the **Settings** tab):
 
 ```
 tools/
@@ -46,6 +47,8 @@ tools/
 
 These executables are required for PNG and WebP optimization. If they are
 missing, the optimizer will skip the corresponding formats.
+The fields are prefilled with `tools/optimizers/optipng.exe` and
+`tools/optimizers/cwebp.exe` but you can override them in the **Settings** tab.
 
 ### Flask Server (Optional)
 `flask_server.py` exposes a small HTTP API for uploading and listing product files. Start it separately if needed:

--- a/config.py
+++ b/config.py
@@ -6,3 +6,8 @@ BASE_DIR = r"C:\\Users\\Lamine\\Desktop\\woocommerce\\code\\CODE POUR BOB"
 # Default paths for Chrome driver and binary
 CHROME_DRIVER_PATH = os.path.join(BASE_DIR, r"../chromdrivers 137/chromedriver-win64/chromedriver.exe")
 CHROME_BINARY_PATH = os.path.join(BASE_DIR, r"../chromdrivers 137/chrome-win64/chrome.exe")
+
+# Default paths for image optimizers
+_OPT_DIR = os.path.join(os.path.dirname(__file__), "tools", "optimizers")
+OPTIPNG_PATH = os.path.join(_OPT_DIR, "optipng.exe")
+CWEBP_PATH = os.path.join(_OPT_DIR, "cwebp.exe")


### PR DESCRIPTION
## Summary
- add OPTIPNG_PATH and CWEBP_PATH defaults in `config.py`
- allow configuring optimizer executables in Settings page
- show rich-text error message when executables are missing
- persist chosen optimizer paths in `optimizer_paths.json`
- update README about setting optimizer paths

## Testing
- `python -m py_compile main.py config.py optimizer.py`

------
https://chatgpt.com/codex/tasks/task_e_6840bd9e5af08330afc0fdbcfe789abc