### PR TITLE
Add environment-based configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,15 +11,26 @@ pip install -r requirements.txt
 ```
 
 ## Configuring Paths
-Edit `config.py` and update the following variables so that they point to your local installation:
+Paths are read from environment variables so you can customise them without
+modifying the source. Set the following variables before running the scripts
+(or adjust the defaults in `config.py`):
 
-```python
-BASE_DIR = r"C:\\path\\to\\project"
-CHROME_DRIVER_PATH = os.path.join(BASE_DIR, r"path/to/chromedriver.exe")
-CHROME_BINARY_PATH = os.path.join(BASE_DIR, r"path/to/chrome.exe")
+* `BASE_DIR` – directory used to store generated files
+* `CHROME_DRIVER_PATH` – path to your `chromedriver` executable
+* `CHROME_BINARY_PATH` – path to the Chrome binary
+* `SUFFIX_FILE_PATH` – file containing custom suffixes for `scraper_images.py`
+* `LINKS_FILE_PATH` – text file listing product URLs
+
+Example on Linux/macOS:
+
+```bash
+export BASE_DIR=/path/to/project
+export CHROME_DRIVER_PATH=/path/to/chromedriver
+export CHROME_BINARY_PATH=/path/to/chrome
 ```
 
-`BASE_DIR` defines where scraped data and output files will be stored. The paths for `CHROME_DRIVER_PATH` and `CHROME_BINARY_PATH` must correspond to your Chrome driver and Chrome executable.
+If these variables are not set, reasonable defaults defined in `config.py` are
+used.
 
 ## Running the Application
 Launch the GUI application with:

--- a/config.py
+++ b/config.py
@@ -1,13 +1,37 @@
 import os
 
-# Default base directory (update as needed)
-BASE_DIR = r"C:\\Users\\Lamine\\Desktop\\woocommerce\\code\\CODE POUR BOB"
+# Default base directory (can be overridden via the BASE_DIR environment variable)
+BASE_DIR = os.environ.get(
+    "BASE_DIR",
+    r"C:\\Users\\Lamine\\Desktop\\woocommerce\\code\\CODE POUR BOB",
+)
 
-# Default paths for Chrome driver and binary
-CHROME_DRIVER_PATH = os.path.join(BASE_DIR, r"../chromdrivers 137/chromedriver-win64/chromedriver.exe")
-CHROME_BINARY_PATH = os.path.join(BASE_DIR, r"../chromdrivers 137/chrome-win64/chrome.exe")
+# Default paths for Chrome driver and binary; can be overridden with
+# CHROME_DRIVER_PATH and CHROME_BINARY_PATH environment variables
+CHROME_DRIVER_PATH = os.environ.get(
+    "CHROME_DRIVER_PATH",
+    os.path.join(
+        BASE_DIR,
+        r"../chromdrivers 137/chromedriver-win64/chromedriver.exe",
+    ),
+)
+CHROME_BINARY_PATH = os.environ.get(
+    "CHROME_BINARY_PATH",
+    os.path.join(BASE_DIR, r"../chromdrivers 137/chrome-win64/chrome.exe"),
+)
 
 # Default paths for image optimizers
 _OPT_DIR = os.path.join(os.path.dirname(__file__), "tools", "optimizers")
 OPTIPNG_PATH = os.path.join(_OPT_DIR, "optipng.exe")
 CWEBP_PATH = os.path.join(_OPT_DIR, "cwebp.exe")
+
+# Optional configuration for scraper_images.py
+SUFFIX_FILE_PATH = os.environ.get(
+    "SUFFIX_FILE_PATH",
+    r"C:\\Users\\Lamine\\Desktop\\woocommerce\\code\\custom_suffixes.py",
+)
+LINKS_FILE_PATH = os.environ.get(
+    "LINKS_FILE_PATH",
+    r"C:\\Users\\Lamine\\Desktop\\woocommerce\\code\\liens_clean.txt",
+)
+ROOT_FOLDER = os.environ.get("ROOT_FOLDER", "image")

--- a/scraper_images.py
+++ b/scraper_images.py
@@ -10,10 +10,11 @@ from selenium.webdriver.chrome.service import Service
 from selenium.webdriver.common.by import By
 from selenium.webdriver.chrome.options import Options
 import importlib.util
+import config
 
 # === CONFIGURATION ===
-CHROMEDRIVER_PATH = r"C:\WebDriver\bin\chromedriver.exe"
-ROOT_FOLDER = "image"
+CHROMEDRIVER_PATH = config.CHROME_DRIVER_PATH
+ROOT_FOLDER = config.ROOT_FOLDER
 os.makedirs(ROOT_FOLDER, exist_ok=True)
 
 # === IMPORT DES SUFFIXES PERSONNALISÉS ===
@@ -23,7 +24,7 @@ def import_custom_suffixes(path):
     spec.loader.exec_module(module)
     return module.custom_suffixes
 
-suffix_file_path = r"C:\Users\Lamine\Desktop\woocommerce\code\custom_suffixes.py"
+suffix_file_path = config.SUFFIX_FILE_PATH
 custom_suffixes = import_custom_suffixes(suffix_file_path)
 
 # Slugifie toutes les clés du dictionnaire
@@ -41,7 +42,7 @@ def read_links_from_txt(path):
     with open(path, "r", encoding="utf-8") as f:
         return [line.strip() for line in f if line.strip()]
 
-links_file_path = r"C:\Users\Lamine\Desktop\woocommerce\code\liens_clean.txt"
+links_file_path = config.LINKS_FILE_PATH
 product_urls = read_links_from_txt(links_file_path)
 
 # === FONCTIONS UTILES ===


### PR DESCRIPTION
## Summary
- pull directory/driver paths from environment variables in `config.py`
- update `scraper_images.py` to read paths from `config`
- document environment variables in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68417d9be4b48330b37dd26176820720