### PR TITLE
Fix missing grid layout import

### DIFF
--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -1,6 +1,7 @@
 from PySide6.QtWidgets import (
-    QWidget, QVBoxLayout, QHBoxLayout, QListWidget, QListWidgetItem,
-    QLabel, QLineEdit, QFrame, QPushButton, QStackedLayout, QStyle
+    QWidget, QVBoxLayout, QHBoxLayout, QGridLayout,  # added QGridLayout
+    QListWidget, QListWidgetItem, QLabel, QLineEdit,
+    QFrame, QPushButton, QStackedLayout, QStyle
 )
 from PySide6.QtCore import Qt
 from PySide6.QtGui import QIcon


### PR DESCRIPTION
## Summary
- include `QGridLayout` in DashboardWindow's imports

## Testing
- `python -m py_compile ui/main_window.py`

------
https://chatgpt.com/codex/tasks/task_e_6841813be9108330b469012180a26e4d