### PR TITLE
Add visual selector page

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,13 @@ You can clear the console or save its contents to a log file using the buttons
 provided. The paths to `optipng.exe` and `cwebp.exe` can be changed at any time
 in the **Settings** tab.
 
+### Using the Visual Selector Tab
+Open the **Sélecteur visuel** tab from the sidebar and enter the URL of a
+product page. After the page loads, move the mouse over the web page to
+highlight elements and click one to generate a CSS selector. You can **Copier**
+the selector to the clipboard or **Sauvegarder** it. Saved selectors are stored
+in `selectors.json` at the root of the project.
+
 ### Flask Server (Optional)
 `flask_server.py` exposes a small HTTP API for uploading and listing product files. Start it separately if needed:
 

--- a/ui/base_window.py
+++ b/ui/base_window.py
@@ -280,9 +280,17 @@ class MainWindow(QMainWindow):
         self.btn_scraper = QPushButton("Scraper")
         self.btn_images = QPushButton("Scraping d'image")
         self.btn_optimizer = QPushButton("Optimiser Images")
+        self.btn_selector = QPushButton("Sélecteur visuel")
         self.btn_api = QPushButton("API Flask")
         self.btn_settings = QPushButton("Paramètres")
-        for btn in (self.btn_scraper, self.btn_images, self.btn_optimizer, self.btn_api, self.btn_settings):
+        for btn in (
+            self.btn_scraper,
+            self.btn_images,
+            self.btn_optimizer,
+            self.btn_selector,
+            self.btn_api,
+            self.btn_settings,
+        ):
             btn.setMinimumHeight(40)
             sidebar_layout.addWidget(btn)
 
@@ -295,12 +303,14 @@ class MainWindow(QMainWindow):
         # Pages
         self.page_scraper = self._create_scraper_page()
         self.page_image = self._create_image_page()
+        self.page_selector = self._create_visual_selector_page()
         self.page_optimizer = self._create_optimizer_page()
         self.page_api = self._create_api_page()
         self.page_settings = self._create_settings_page()
 
         self.stack.addWidget(self.page_scraper)
         self.stack.addWidget(self.page_image)
+        self.stack.addWidget(self.page_selector)
         self.stack.addWidget(self.page_optimizer)
         self.stack.addWidget(self.page_api)
         self.stack.addWidget(self.page_settings)
@@ -308,6 +318,7 @@ class MainWindow(QMainWindow):
         self.btn_scraper.clicked.connect(lambda: self._show_page(self.page_scraper))
         self.btn_images.clicked.connect(lambda: self._show_page(self.page_image))
         self.btn_optimizer.clicked.connect(lambda: self._show_page(self.page_optimizer))
+        self.btn_selector.clicked.connect(lambda: self._show_page(self.page_selector))
         self.btn_api.clicked.connect(lambda: self.stack.setCurrentWidget(self.page_api))
         self.btn_settings.clicked.connect(lambda: self.stack.setCurrentWidget(self.page_settings))
 
@@ -512,6 +523,11 @@ class MainWindow(QMainWindow):
         self.preview_list.setIconSize(QSize(80, 80))
         layout.addWidget(self.preview_list)
 
+        return page
+
+    def _create_visual_selector_page(self):
+        from ui.visual_selector import VisualSelectorPage
+        page = VisualSelectorPage()
         return page
 
     def _create_optimizer_page(self):

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -54,6 +54,7 @@ class DashboardWindow(MainWindow):
             ("Accueil", QStyle.SP_DesktopIcon),
             ("Scraper", QStyle.SP_FileIcon),
             ("Scraping d'image", QStyle.SP_DirIcon),
+            ("Sélecteur visuel", QStyle.SP_DialogOpenButton),
             ("Optimiseur d'images", QStyle.SP_ComputerIcon),
             ("API Flask", QStyle.SP_BrowserReload),
             ("Paramètres", QStyle.SP_FileDialogDetailedView),
@@ -73,6 +74,7 @@ class DashboardWindow(MainWindow):
         self.page_dashboard = self._create_dashboard_page()
         self.page_scraper = super()._create_scraper_page()
         self.page_image = super()._create_image_page()
+        self.page_selector = super()._create_visual_selector_page()
         self.page_optimizer = super()._create_optimizer_page()
         self.page_api = super()._create_api_page()
         self.page_settings = super()._create_settings_page()
@@ -81,6 +83,7 @@ class DashboardWindow(MainWindow):
             self.page_dashboard,
             self.page_scraper,
             self.page_image,
+            self.page_selector,
             self.page_optimizer,
             self.page_api,
             self.page_settings,

--- a/ui/visual_selector.py
+++ b/ui/visual_selector.py
@@ -1,0 +1,149 @@
+from PySide6.QtCore import QObject, Signal, Slot, QUrl
+from PySide6.QtWidgets import (
+    QApplication,
+    QWidget,
+    QVBoxLayout,
+    QHBoxLayout,
+    QPushButton,
+    QLineEdit,
+)
+from PySide6.QtWebEngineWidgets import QWebEngineView
+from PySide6.QtWebChannel import QWebChannel
+
+import json
+import os
+from urllib.parse import urlparse
+
+# Path to the JSON file storing selectors
+SELECTORS_FILE = os.path.join(os.path.dirname(os.path.dirname(__file__)), "selectors.json")
+
+
+def load_selectors():
+    if os.path.isfile(SELECTORS_FILE):
+        try:
+            with open(SELECTORS_FILE, "r", encoding="utf-8") as f:
+                return json.load(f)
+        except Exception:
+            return {}
+    return {}
+
+
+def save_selectors(data):
+    try:
+        with open(SELECTORS_FILE, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2)
+    except Exception as e:
+        print(f"Erreur sauvegarde sélecteurs: {e}")
+
+
+def save_selector(url, selector):
+    data = load_selectors()
+    domain = urlparse(url).netloc or url
+    data[domain] = selector
+    save_selectors(data)
+
+
+class JSBridge(QObject):
+    selectorReceived = Signal(str)
+
+    @Slot(str)
+    def selectorSelected(self, selector):
+        self.selectorReceived.emit(selector)
+
+
+class VisualSelectorPage(QWidget):
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        layout = QVBoxLayout(self)
+
+        url_layout = QHBoxLayout()
+        self.input_url = QLineEdit()
+        self.input_url.setPlaceholderText("URL de la page")
+        self.btn_open = QPushButton("Ouvrir")
+        url_layout.addWidget(self.input_url)
+        url_layout.addWidget(self.btn_open)
+        layout.addLayout(url_layout)
+
+        self.webview = QWebEngineView()
+        layout.addWidget(self.webview, 1)
+
+        sel_layout = QHBoxLayout()
+        self.input_selector = QLineEdit()
+        self.input_selector.setPlaceholderText("Sélecteur généré")
+        self.btn_copy = QPushButton("Copier")
+        self.btn_save = QPushButton("Sauvegarder")
+        sel_layout.addWidget(self.input_selector)
+        sel_layout.addWidget(self.btn_copy)
+        sel_layout.addWidget(self.btn_save)
+        layout.addLayout(sel_layout)
+
+        # Bridge for JS -> Python communication
+        self.bridge = JSBridge()
+        self.bridge.selectorReceived.connect(self.input_selector.setText)
+        self.channel = QWebChannel()
+        self.channel.registerObject("pyObj", self.bridge)
+        self.webview.page().setWebChannel(self.channel)
+
+        self.btn_open.clicked.connect(self.load_url)
+        self.btn_copy.clicked.connect(self.copy_selector)
+        self.btn_save.clicked.connect(self.save_current_selector)
+        self.webview.loadFinished.connect(self.inject_js)
+
+    def load_url(self):
+        url = self.input_url.text().strip()
+        if url:
+            self.webview.load(QUrl(url))
+
+    def copy_selector(self):
+        QApplication.clipboard().setText(self.input_selector.text())
+
+    def save_current_selector(self):
+        url = self.input_url.text().strip()
+        selector = self.input_selector.text().strip()
+        if url and selector:
+            save_selector(url, selector)
+
+    def inject_js(self):
+        js = """
+            (function() {
+                function cssPath(el) {
+                    if (!(el instanceof Element)) return '';
+                    var path = [];
+                    while (el.nodeType === Node.ELEMENT_NODE) {
+                        var selector = el.nodeName.toLowerCase();
+                        if (el.id) {
+                            selector += '#' + el.id;
+                            path.unshift(selector);
+                            break;
+                        } else {
+                            var sib = el, nth = 1;
+                            while (sib = sib.previousElementSibling) {
+                                if (sib.nodeName.toLowerCase() === selector)
+                                    nth++;
+                            }
+                            if (nth !== 1)
+                                selector += ':nth-of-type(' + nth + ')';
+                        }
+                        path.unshift(selector);
+                        el = el.parentNode;
+                    }
+                    return path.join(' > ');
+                }
+                document.addEventListener('mouseover', function(e){
+                    e.target.__oldOutline = e.target.style.outline;
+                    e.target.style.outline = '2px solid red';
+                }, true);
+                document.addEventListener('mouseout', function(e){
+                    e.target.style.outline = e.target.__oldOutline || '';
+                }, true);
+                document.addEventListener('click', function(e){
+                    e.preventDefault();
+                    e.stopPropagation();
+                    var sel = cssPath(e.target);
+                    if (window.pyObj && window.pyObj.selectorSelected) {
+                        window.pyObj.selectorSelected(sel);
+                    }
+                }, true);
+            })();
+        """
+        self.webview.page().runJavaScript(js)


### PR DESCRIPTION
## Summary
- add new VisualSelectorPage widget for visually capturing CSS selectors
- save selectors in `selectors.json`
- integrate the new page into Base and Dashboard windows
- document the new tab in the README

## Testing
- `python Application.py` *(fails: ModuleNotFoundError: No module named 'PySide6')*

------
https://chatgpt.com/codex/tasks/task_e_6841bcdb30b08330acae4784dee0d219