### PR TITLE
Add auto ChromeDriver download support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Requirements
 - Python 3.10 or newer.
-- Google Chrome and the matching ChromeDriver.
+- Google Chrome. The ChromeDriver binary is downloaded automatically at runtime if `CHROME_DRIVER_PATH` is not provided.
 
 Install the Python dependencies using:
 
@@ -23,8 +23,8 @@ modifying the source. Set the following variables before running the scripts
 (or adjust the defaults in `config.py`):
 
 * `BASE_DIR` – directory used to store generated files
-* `CHROME_DRIVER_PATH` – path to your `chromedriver` executable
-* `CHROME_BINARY_PATH` – path to the Chrome binary
+* `CHROME_DRIVER_PATH` – optional path to a `chromedriver` executable (useful without internet access)
+* `CHROME_BINARY_PATH` – optional path to the Chrome binary
 * `SUFFIX_FILE_PATH` – file containing custom suffixes for `scraper_images.py`
 * `LINKS_FILE_PATH` – text file listing product URLs
 
@@ -32,12 +32,12 @@ Example on Linux/macOS:
 
 ```bash
 export BASE_DIR=/path/to/project
-export CHROME_DRIVER_PATH=/path/to/chromedriver
+export CHROME_DRIVER_PATH=/path/to/chromedriver  # only if you want to skip auto download
 export CHROME_BINARY_PATH=/path/to/chrome
 ```
 
-If these variables are not set, reasonable defaults defined in `config.py` are
-used.
+If `CHROME_DRIVER_PATH` is not set, a driver is downloaded automatically at
+runtime. Other variables fall back to the values defined in `config.py`.
 
 ## Running the Application
 `Application.py` is the unique entry point aggregating the GUI, scraping and optimizer features. Launch the GUI with:

--- a/config.py
+++ b/config.py
@@ -8,17 +8,8 @@ BASE_DIR = os.environ.get(
 
 # Default paths for Chrome driver and binary; can be overridden with
 # CHROME_DRIVER_PATH and CHROME_BINARY_PATH environment variables
-CHROME_DRIVER_PATH = os.environ.get(
-    "CHROME_DRIVER_PATH",
-    os.path.join(
-        BASE_DIR,
-        r"../chromdrivers 137/chromedriver-win64/chromedriver.exe",
-    ),
-)
-CHROME_BINARY_PATH = os.environ.get(
-    "CHROME_BINARY_PATH",
-    os.path.join(BASE_DIR, r"../chromdrivers 137/chrome-win64/chrome.exe"),
-)
+CHROME_DRIVER_PATH = os.environ.get("CHROME_DRIVER_PATH")
+CHROME_BINARY_PATH = os.environ.get("CHROME_BINARY_PATH")
 
 # Default paths for image optimizers
 _OPT_DIR = os.path.join(os.path.dirname(__file__), "tools", "optimizers")

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ requests
 flask
 
 PySide6
+webdriver-manager

--- a/scraper_woocommerce.py
+++ b/scraper_woocommerce.py
@@ -14,6 +14,7 @@ import config
 from selenium import webdriver
 from selenium.webdriver.chrome.service import Service
 from selenium.webdriver.common.by import By
+from webdriver_manager.chrome import ChromeDriverManager
 
 # === CORE CLASS ===
 
@@ -201,9 +202,17 @@ class ScraperCore:
     def scrap_produits_par_ids(self, id_url_map, ids_selectionnes, driver_path=None, binary_path=None, progress_callback=None, should_stop=lambda: False, headless=True):
         driver_path = driver_path or self.chrome_driver_path
         binary_path = binary_path or self.chrome_binary_path
+        if not driver_path:
+            try:
+                driver_path = ChromeDriverManager().install()
+            except Exception as e:
+                self._log(f"❌ Impossible de télécharger ChromeDriver : {e}")
+                self._log("➡️ Spécifiez CHROME_DRIVER_PATH pour un mode hors-ligne.")
+                return 0, len(ids_selectionnes)
         progress_callback = progress_callback or self._update_progress
         options = webdriver.ChromeOptions()
-        options.binary_location = binary_path
+        if binary_path:
+            options.binary_location = binary_path
         if headless:
             options.add_argument("--headless")
         options.add_argument('--disable-blink-features=AutomationControlled')
@@ -326,10 +335,18 @@ class ScraperCore:
     def scrap_fiches_concurrents(self, id_url_map, ids_selectionnes, driver_path=None, binary_path=None, progress_callback=None, should_stop=lambda: False, headless=True):
         driver_path = driver_path or self.chrome_driver_path
         binary_path = binary_path or self.chrome_binary_path
+        if not driver_path:
+            try:
+                driver_path = ChromeDriverManager().install()
+            except Exception as e:
+                self._log(f"❌ Impossible de télécharger ChromeDriver : {e}")
+                self._log("➡️ Spécifiez CHROME_DRIVER_PATH pour un mode hors-ligne.")
+                return 0, len(ids_selectionnes)
         progress_callback = progress_callback or self._update_progress
         service = Service(executable_path=driver_path)
         options = webdriver.ChromeOptions()
-        options.binary_location = binary_path
+        if binary_path:
+            options.binary_location = binary_path
         options.add_experimental_option("excludeSwitches", ["enable-automation"])
         options.add_experimental_option('useAutomationExtension', False)
         options.add_argument("--disable-blink-features=AutomationControlled")
@@ -500,10 +517,18 @@ class ScraperCore:
     ):
         driver_path = driver_path or self.chrome_driver_path
         binary_path = binary_path or self.chrome_binary_path
+        if not driver_path:
+            try:
+                driver_path = ChromeDriverManager().install()
+            except Exception as e:
+                self._log(f"❌ Impossible de télécharger ChromeDriver : {e}")
+                self._log("➡️ Spécifiez CHROME_DRIVER_PATH pour un mode hors-ligne.")
+                return "Erreur téléchargement ChromeDriver"
         progress_callback = progress_callback or self._update_progress
 
         options = webdriver.ChromeOptions()
-        options.binary_location = binary_path
+        if binary_path:
+            options.binary_location = binary_path
         options.add_argument("--disable-blink-features=AutomationControlled")
         options.add_experimental_option("excludeSwitches", ["enable-automation"])
         options.add_experimental_option("useAutomationExtension", False)

--- a/ui/base_window.py
+++ b/ui/base_window.py
@@ -628,7 +628,7 @@ class MainWindow(QMainWindow):
 
         layout.addWidget(QLabel("Chemin du chromedriver"))
         driver_layout = QHBoxLayout()
-        self.input_driver_path = QLineEdit(config.CHROME_DRIVER_PATH)
+        self.input_driver_path = QLineEdit(config.CHROME_DRIVER_PATH or "")
         btn_driver = QPushButton("Parcourir")
         btn_driver.clicked.connect(self._choose_driver_path)
         driver_layout.addWidget(self.input_driver_path)
@@ -637,7 +637,7 @@ class MainWindow(QMainWindow):
 
         layout.addWidget(QLabel("Chemin du navigateur Chrome"))
         binary_layout = QHBoxLayout()
-        self.input_binary_path = QLineEdit(config.CHROME_BINARY_PATH)
+        self.input_binary_path = QLineEdit(config.CHROME_BINARY_PATH or "")
         btn_binary = QPushButton("Parcourir")
         btn_binary.clicked.connect(self._choose_binary_path)
         binary_layout.addWidget(self.input_binary_path)


### PR DESCRIPTION
## Summary
- make `CHROME_DRIVER_PATH` optional
- pull ChromeDriver with webdriver-manager when no path is provided
- allow optional Chrome binary path
- handle download errors with a helpful message
- document automatic download behaviour
- include webdriver-manager in requirements

## Testing
- `python -m py_compile scraper_woocommerce.py scraper_images.py config.py ui/base_window.py`

------
https://chatgpt.com/codex/tasks/task_e_6841c0bf8c4c8330adc9c379c8d5693d