### PR TITLE
Update default config paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,14 +19,20 @@ python Application.py
 
 ## Configuring Paths
 Paths are read from environment variables so you can customise them without
-modifying the source. Set the following variables before running the scripts
-(or adjust the defaults in `config.py`):
+modifying the source. The defaults are defined in `config.py`:
 
-* `BASE_DIR` – directory used to store generated files
-* `CHROME_DRIVER_PATH` – optional path to a `chromedriver` executable (useful without internet access)
+* `BASE_DIR` – directory used to store generated files. Defaults to the folder
+  containing `config.py`.
+* `CHROME_DRIVER_PATH` – optional path to a `chromedriver` executable (useful
+  without internet access)
 * `CHROME_BINARY_PATH` – optional path to the Chrome binary
-* `SUFFIX_FILE_PATH` – file containing custom suffixes for `scraper_images.py`
-* `LINKS_FILE_PATH` – text file listing product URLs
+* `SUFFIX_FILE_PATH` – file containing custom suffixes for `scraper_images.py`.
+  Defaults to `BASE_DIR/custom_suffixes.py`.
+* `LINKS_FILE_PATH` – text file listing product URLs. Defaults to
+  `BASE_DIR/liens_clean.txt`.
+
+Set the environment variables to override these locations when running the
+scripts.
 
 Example on Linux/macOS:
 

--- a/config.py
+++ b/config.py
@@ -3,7 +3,7 @@ import os
 # Default base directory (can be overridden via the BASE_DIR environment variable)
 BASE_DIR = os.environ.get(
     "BASE_DIR",
-    r"C:\\Users\\Lamine\\Desktop\\woocommerce\\code\\CODE POUR BOB",
+    os.path.dirname(os.path.abspath(__file__)),
 )
 
 # Default paths for Chrome driver and binary; can be overridden with
@@ -19,10 +19,10 @@ CWEBP_PATH = os.path.join(_OPT_DIR, "cwebp.exe")
 # Optional configuration for scraper_images.py
 SUFFIX_FILE_PATH = os.environ.get(
     "SUFFIX_FILE_PATH",
-    r"C:\\Users\\Lamine\\Desktop\\woocommerce\\code\\custom_suffixes.py",
+    os.path.join(BASE_DIR, "custom_suffixes.py"),
 )
 LINKS_FILE_PATH = os.environ.get(
     "LINKS_FILE_PATH",
-    r"C:\\Users\\Lamine\\Desktop\\woocommerce\\code\\liens_clean.txt",
+    os.path.join(BASE_DIR, "liens_clean.txt"),
 )
 ROOT_FOLDER = os.environ.get("ROOT_FOLDER", "image")


### PR DESCRIPTION
## Summary
- default `BASE_DIR` to repository directory
- derive `SUFFIX_FILE_PATH` and `LINKS_FILE_PATH` from `BASE_DIR`
- document new defaults and how to override them

## Testing
- `python -m pytest`
- `python -m py_compile config.py scraper_images.py main.py Application.py optimizer.py scraper_woocommerce.py flask_server.py`


------
https://chatgpt.com/codex/tasks/task_e_6841da4d77c48330912e3d78c1ff5dbb