### PR TITLE
Switch to TOML-based configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Requirements
 - Python 3.10 or newer.
-- Google Chrome. The ChromeDriver binary is downloaded automatically at runtime if `CHROME_DRIVER_PATH` is not provided.
+- Google Chrome. The ChromeDriver binary is downloaded automatically at runtime if `CHROME_DRIVER_PATH` is empty.
 
 Install the Python dependencies using:
 
@@ -18,8 +18,23 @@ python Application.py
 ```
 
 ## Configuring Paths
-Paths are read from environment variables so you can customise them without
-modifying the source. The defaults are defined in `config.py`:
+Paths are stored in a `config.toml` file located at the repository root. If the
+file does not exist, default values from `config_manager.py` are used. The file
+contains entries such as:
+
+```toml
+BASE_DIR = "/path/to/project"
+CHROME_DRIVER_PATH = "/path/to/chromedriver"
+CHROME_BINARY_PATH = "/path/to/chrome"
+SUFFIX_FILE_PATH = "/path/to/custom_suffixes.py"
+LINKS_FILE_PATH = "/path/to/liens_clean.txt"
+OPTIPNG_PATH = "tools/optimizers/optipng.exe"
+CWEBP_PATH = "tools/optimizers/cwebp.exe"
+ROOT_FOLDER = "image"
+```
+
+You can edit this file directly or use the **Settings** page in the GUI which
+updates it automatically. The defaults mirror the previous behaviour:
 
 * `BASE_DIR` – directory used to store generated files. Defaults to the folder
   containing `config.py`.
@@ -33,21 +48,8 @@ modifying the source. The defaults are defined in `config.py`:
 
 A minimal template file `custom_suffixes.example.py` is included in the
 repository. Copy it to `custom_suffixes.py` and edit it to provide your own
-suffixes.
-
-Set the environment variables to override these locations when running the
-scripts.
-
-Example on Linux/macOS:
-
-```bash
-export BASE_DIR=/path/to/project
-export CHROME_DRIVER_PATH=/path/to/chromedriver  # only if you want to skip auto download
-export CHROME_BINARY_PATH=/path/to/chrome
-```
-
-If `CHROME_DRIVER_PATH` is not set, a driver is downloaded automatically at
-runtime. Other variables fall back to the values defined in `config.py`.
+suffixes. If `CHROME_DRIVER_PATH` is empty, a driver is downloaded
+automatically at runtime.
 
 ## Running the Application
 `Application.py` is the unique entry point aggregating the GUI, scraping and optimizer features. Launch the GUI with:

--- a/config.py
+++ b/config.py
@@ -1,28 +1,32 @@
+from __future__ import annotations
 import os
+from typing import Dict
 
-# Default base directory (can be overridden via the BASE_DIR environment variable)
-BASE_DIR = os.environ.get(
-    "BASE_DIR",
-    os.path.dirname(os.path.abspath(__file__)),
-)
+import config_manager
 
-# Default paths for Chrome driver and binary; can be overridden with
-# CHROME_DRIVER_PATH and CHROME_BINARY_PATH environment variables
-CHROME_DRIVER_PATH = os.environ.get("CHROME_DRIVER_PATH")
-CHROME_BINARY_PATH = os.environ.get("CHROME_BINARY_PATH")
+_cfg = config_manager.load()
 
-# Default paths for image optimizers
+BASE_DIR = _cfg["BASE_DIR"]
+CHROME_DRIVER_PATH = _cfg["CHROME_DRIVER_PATH"]
+CHROME_BINARY_PATH = _cfg["CHROME_BINARY_PATH"]
 _OPT_DIR = os.path.join(os.path.dirname(__file__), "tools", "optimizers")
-OPTIPNG_PATH = os.path.join(_OPT_DIR, "optipng.exe")
-CWEBP_PATH = os.path.join(_OPT_DIR, "cwebp.exe")
+OPTIPNG_PATH = _cfg["OPTIPNG_PATH"]
+CWEBP_PATH = _cfg["CWEBP_PATH"]
+SUFFIX_FILE_PATH = _cfg["SUFFIX_FILE_PATH"]
+LINKS_FILE_PATH = _cfg["LINKS_FILE_PATH"]
+ROOT_FOLDER = _cfg["ROOT_FOLDER"]
 
-# Optional configuration for scraper_images.py
-SUFFIX_FILE_PATH = os.environ.get(
-    "SUFFIX_FILE_PATH",
-    os.path.join(BASE_DIR, "custom_suffixes.py"),
-)
-LINKS_FILE_PATH = os.environ.get(
-    "LINKS_FILE_PATH",
-    os.path.join(BASE_DIR, "liens_clean.txt"),
-)
-ROOT_FOLDER = os.environ.get("ROOT_FOLDER", "image")
+
+def reload() -> Dict[str, str | None]:
+    """Reload configuration from disk and update module globals."""
+    global BASE_DIR, CHROME_DRIVER_PATH, CHROME_BINARY_PATH, OPTIPNG_PATH, CWEBP_PATH, SUFFIX_FILE_PATH, LINKS_FILE_PATH, ROOT_FOLDER
+    _new = config_manager.load()
+    BASE_DIR = _new["BASE_DIR"]
+    CHROME_DRIVER_PATH = _new["CHROME_DRIVER_PATH"]
+    CHROME_BINARY_PATH = _new["CHROME_BINARY_PATH"]
+    OPTIPNG_PATH = _new["OPTIPNG_PATH"]
+    CWEBP_PATH = _new["CWEBP_PATH"]
+    SUFFIX_FILE_PATH = _new["SUFFIX_FILE_PATH"]
+    LINKS_FILE_PATH = _new["LINKS_FILE_PATH"]
+    ROOT_FOLDER = _new["ROOT_FOLDER"]
+    return _new

--- a/config_manager.py
+++ b/config_manager.py
@@ -1,0 +1,54 @@
+import os
+import json
+import tomllib
+
+CONFIG_FILE = os.path.join(os.path.dirname(__file__), "config.toml")
+
+_DEFAULT_BASE = os.path.dirname(os.path.abspath(__file__))
+_DEFAULT_OPT_DIR = os.path.join(os.path.dirname(__file__), "tools", "optimizers")
+
+DEFAULTS = {
+    "BASE_DIR": _DEFAULT_BASE,
+    "CHROME_DRIVER_PATH": None,
+    "CHROME_BINARY_PATH": None,
+    "OPTIPNG_PATH": os.path.join(_DEFAULT_OPT_DIR, "optipng.exe"),
+    "CWEBP_PATH": os.path.join(_DEFAULT_OPT_DIR, "cwebp.exe"),
+    "SUFFIX_FILE_PATH": os.path.join(_DEFAULT_BASE, "custom_suffixes.py"),
+    "LINKS_FILE_PATH": os.path.join(_DEFAULT_BASE, "liens_clean.txt"),
+    "ROOT_FOLDER": "image",
+}
+
+
+def load(path: str = CONFIG_FILE) -> dict:
+    """Load configuration from *path* and return a dict of values."""
+    cfg = DEFAULTS.copy()
+    if os.path.isfile(path):
+        try:
+            with open(path, "rb") as f:
+                content = f.read()
+            try:
+                data = tomllib.loads(content.decode("utf-8"))
+            except Exception:
+                data = json.loads(content.decode("utf-8"))
+            for key in DEFAULTS:
+                if key in data and data[key] not in ("", None):
+                    cfg[key] = data[key]
+        except Exception as e:
+            print(f"Error reading {path}: {e}")
+    return cfg
+
+
+def save(cfg: dict, path: str = CONFIG_FILE) -> None:
+    """Write configuration dictionary to *path* in a minimal TOML format."""
+    lines = []
+    for key, value in cfg.items():
+        if value is None:
+            value = ""
+        escaped = str(value).replace("\"", "\\\"")
+        lines.append(f'{key} = "{escaped}"')
+    tmp = "\n".join(lines)
+    try:
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(tmp)
+    except Exception as e:
+        print(f"Error writing {path}: {e}")


### PR DESCRIPTION
## Summary
- add config_manager for TOML config handling
- load config from config_manager in config.py
- persist updated paths from the UI settings page
- document usage of `config.toml` instead of environment variables

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6841dd25a2688330afae1885248d541b