### PR TITLE
Implement logging and scraping resume

### DIFF
--- a/Application.py
+++ b/Application.py
@@ -1,4 +1,5 @@
 import sys
+import logger_setup  # noqa: F401  # configure logging
 from PySide6.QtWidgets import QApplication
 from ui.main_window import DashboardWindow
 

--- a/README.md
+++ b/README.md
@@ -123,5 +123,15 @@ python flask_server.py
 
 The server listens on port `5000` by default.
 
+## Logging
+All console output is also written to `logs/app.log` at the repository root. The
+file rotates automatically when it reaches about 1 MB.
+
+## Resuming a Scrape
+During scraping, progress is stored in `scraping_checkpoint.json` inside
+`BASE_DIR`. If the process stops unexpectedly, run
+`ScraperCore.start_scraping(resume=True)` with the same parameters to continue
+from the last checkpoint.
+
 ## License
 This project is licensed under the MIT License. See the [LICENSE](LICENSE) file for details.

--- a/logger_setup.py
+++ b/logger_setup.py
@@ -1,0 +1,14 @@
+import logging
+import os
+from logging.handlers import RotatingFileHandler
+
+LOG_DIR = os.path.join(os.path.dirname(__file__), "logs")
+os.makedirs(LOG_DIR, exist_ok=True)
+LOG_FILE = os.path.join(LOG_DIR, "app.log")
+
+handler = RotatingFileHandler(LOG_FILE, maxBytes=1_000_000, backupCount=3, encoding="utf-8")
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+    handlers=[handler, logging.StreamHandler()]
+)


### PR DESCRIPTION
## Summary
- configure a rotating log file in `logs/app.log`
- log messages through Python logging
- save/resume scraping progress with a checkpoint file
- document log location and resume flag

## Testing
- `python -m py_compile scraper_woocommerce.py Application.py logger_setup.py`

------
https://chatgpt.com/codex/tasks/task_e_6841e0386a608330a987dff457070d3f