### PR TITLE
Add command line interface for scraping

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,5 +133,37 @@ During scraping, progress is stored in `scraping_checkpoint.json` inside
 `ScraperCore.start_scraping(resume=True)` with the same parameters to continue
 from the last checkpoint.
 
+## Command Line Interface
+
+Installing the project with `pip install .` exposes a `woocommerce-scraper`
+command that provides a few helpful utilities:
+
+```bash
+woocommerce-scraper scrape            # scrape descriptions
+woocommerce-scraper scrape-images     # download product images
+woocommerce-scraper optimize FOLDER   # optimize images inside FOLDER
+woocommerce-scraper resume            # continue a previous scrape
+```
+
+### Automating with Cron (Linux/macOS)
+
+Add a cron entry with `crontab -e` to run the scraper periodically. For example
+to start every day at 3 AM:
+
+```cron
+0 3 * * * /usr/bin/woocommerce-scraper scrape >> /path/to/log.txt 2>&1
+```
+
+### Automating with Windows Task Scheduler
+
+Create a new **Basic Task** and set the action to start `cmd.exe` with the
+argument:
+
+```
+/C woocommerce-scraper scrape
+```
+
+Ensure that Python and the console script are in the system `PATH`.
+
 ## License
 This project is licensed under the MIT License. See the [LICENSE](LICENSE) file for details.

--- a/cli.py
+++ b/cli.py
@@ -1,0 +1,102 @@
+import argparse
+import os
+import logger_setup  # noqa: F401
+import config
+from scraper_woocommerce import ScraperCore
+from optimizer import ImageOptimizer
+
+
+def run_scrape(args):
+    core = ScraperCore(
+        base_dir=config.BASE_DIR,
+        chrome_driver_path=config.CHROME_DRIVER_PATH,
+        chrome_binary_path=config.CHROME_BINARY_PATH,
+    )
+    id_url_map = core.charger_liens_avec_id(config.LINKS_FILE_PATH)
+    ids = list(id_url_map.keys())
+    summary = core.start_scraping(
+        id_url_map,
+        ids,
+        ["variantes", "concurrents", "json"],
+        driver_path=config.CHROME_DRIVER_PATH,
+        binary_path=config.CHROME_BINARY_PATH,
+        headless=args.headless,
+        concurrent=args.concurrent,
+        resume=args.resume,
+    )
+    print(summary)
+
+
+def run_scrape_images(args):
+    core = ScraperCore(
+        base_dir=config.BASE_DIR,
+        chrome_driver_path=config.CHROME_DRIVER_PATH,
+        chrome_binary_path=config.CHROME_BINARY_PATH,
+    )
+    urls = core.charger_liste_urls(config.LINKS_FILE_PATH)
+    dest = os.path.join(config.BASE_DIR, config.ROOT_FOLDER)
+    result = core.scrap_images(
+        urls,
+        dest,
+        driver_path=config.CHROME_DRIVER_PATH,
+        binary_path=config.CHROME_BINARY_PATH,
+        suffix=args.suffix,
+        headless=args.headless,
+    )
+    print(result)
+
+
+def run_optimize(args):
+    optimizer = ImageOptimizer(config.OPTIPNG_PATH, config.CWEBP_PATH)
+    logs = optimizer.optimize_folder(args.folder)
+    for line in logs:
+        print(line)
+
+
+def run_resume(args):
+    args.resume = True
+    run_scrape(args)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="woocommerce-scraper",
+        description="Command line tools for the WooCommerce scraper",
+    )
+    sub = parser.add_subparsers(dest="command")
+
+    p_scrape = sub.add_parser("scrape", help="Scrape product descriptions")
+    p_scrape.add_argument("--headless", action="store_true", help="Run Chrome headless")
+    p_scrape.add_argument("--concurrent", action="store_true", help="Use async scraping")
+    p_scrape.add_argument("--resume", action="store_true", help="Resume from checkpoint")
+    p_scrape.set_defaults(func=run_scrape)
+
+    p_images = sub.add_parser("scrape-images", help="Scrape product images")
+    p_images.add_argument("--headless", action="store_true", help="Run Chrome headless")
+    p_images.add_argument("--suffix", default="image-produit", help="Suffix for alt text")
+    p_images.set_defaults(func=run_scrape_images)
+
+    p_opt = sub.add_parser("optimize", help="Optimize an image folder")
+    p_opt.add_argument("folder", help="Folder containing images")
+    p_opt.set_defaults(func=run_optimize)
+
+    p_resume = sub.add_parser("resume", help="Resume a previous scraping run")
+    p_resume.add_argument("--headless", action="store_true", help="Run Chrome headless")
+    p_resume.add_argument("--concurrent", action="store_true", help="Use async scraping")
+    p_resume.set_defaults(func=run_resume)
+
+    return parser
+
+
+def main(argv=None):
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if not hasattr(args, "func"):
+        parser.print_help()
+        return 1
+    args.func(args)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,21 @@
+[project]
+name = "woocommerce-scraper"
+version = "0.1.0"
+description = "Tools for scraping WooCommerce products"
+authors = [{name = "Unknown"}]
+requires-python = ">=3.10"
+dependencies = [
+    "selenium",
+    "beautifulsoup4",
+    "pandas",
+    "openpyxl",
+    "requests",
+    "flask",
+    "PySide6",
+    "webdriver-manager",
+    "playwright",
+]
+
+[project.scripts]
+woocommerce-scraper = "cli:main"
+


### PR DESCRIPTION
## Summary
- add a CLI with scrape, scrape-images, optimize and resume commands
- configure an installable console script via `pyproject.toml`
- document the CLI and automation with cron/Task Scheduler

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841e1dad9a48330a8422ce06b755e69