### PR TITLE
Add unit tests and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+on:
+  push:
+    branches: ["*"]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install deps
+        run: |
+          python -m pip install -r requirements.txt
+          python -m pip install pytest
+      - name: Run tests
+        run: pytest -q

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Setup and Usage
+[![CI](https://github.com/USER/REPO/actions/workflows/ci.yml/badge.svg)](https://github.com/USER/REPO/actions/workflows/ci.yml)
 
 ## Requirements
 - Python 3.10 or newer.
@@ -22,6 +23,13 @@ playwright install
 ```bash
 pip install -r requirements.txt
 python Application.py
+```
+
+### Running Tests
+
+```bash
+pip install -r requirements.txt
+pytest
 ```
 
 ### Asynchronous Scraping

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,6 @@ flask
 PySide6
 webdriver-manager
 playwright
+
+# Development
+pytest

--- a/tests/data/simple.html
+++ b/tests/data/simple.html
@@ -1,0 +1,6 @@
+<html>
+<body>
+<h1>Basic Product</h1>
+<span class="price">12.34 €</span>
+</body>
+</html>

--- a/tests/data/variable.html
+++ b/tests/data/variable.html
@@ -1,0 +1,8 @@
+<html>
+<body>
+<h1>Colorful Item</h1>
+<span class="woocommerce-Price-amount">9,99</span>
+<label class="color-swatch"><span class="sr-only">Red</span></label>
+<label class="color-swatch"><span class="sr-only">Green</span></label>
+</body>
+</html>

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,0 +1,69 @@
+import os
+import pandas as pd
+import asyncio
+import pytest
+
+from scraper_woocommerce import ScraperCore
+import scraper_woocommerce
+
+
+class DummyBrowser:
+    async def close(self):
+        pass
+
+class DummyChromium:
+    async def launch(self, headless=True):
+        return DummyBrowser()
+
+class DummyPlay:
+    chromium = DummyChromium()
+    async def __aenter__(self):
+        return self
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_scrap_produits_parsing(monkeypatch, tmp_path):
+    simple_html = (tmp_path / "simple.html")
+    variable_html = (tmp_path / "variable.html")
+    # copy example data
+    data_dir = os.path.join(os.path.dirname(__file__), "data")
+    simple_html.write_text(open(os.path.join(data_dir, "simple.html")).read())
+    variable_html.write_text(open(os.path.join(data_dir, "variable.html")).read())
+
+    html_map = {
+        "http://simple": simple_html.read_text(),
+        "http://var": variable_html.read_text(),
+    }
+
+    async def fake_scrape(self, browser, url):
+        return html_map[url]
+
+    monkeypatch.setattr(scraper_woocommerce, "async_playwright", lambda: DummyPlay())
+    monkeypatch.setattr(ScraperCore, "async_scrape_product", fake_scrape)
+
+    captured = {}
+    monkeypatch.setattr(pd.DataFrame, "to_excel", lambda self, path, index=False: captured.setdefault("df", self))
+
+    core = ScraperCore(base_dir=tmp_path)
+    id_url_map = {"1": "http://simple", "2": "http://var"}
+    ids = ["1", "2"]
+    ok, err = await core._scrap_produits_par_ids_async(id_url_map, ids, [], None, lambda: False, True)
+
+    df = captured.get("df")
+    assert ok == 2
+    assert err == 0
+    assert len(df) == 4
+    simple_row = df[df["ID Produit"] == "1"].iloc[0]
+    assert simple_row["Type"] == "simple"
+    assert simple_row["Name"] == "Basic Product"
+    variable_rows = df[df["ID Produit"] == "2"]
+    assert set(variable_rows["Type"]) == {"variable", "variation"}
+    var_parent = variable_rows[variable_rows["Type"] == "variable"].iloc[0]
+    assert var_parent["Attribute 1 value(s)"] == "Red | Green"
+
+
+def test_clean_helpers():
+    assert ScraperCore.clean_name("Crème Brûlée-") == "creme brulee"
+    assert ScraperCore.clean_filename("Crème Brûlée!.jpg") == "creme-bruleejpg"

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -1,0 +1,51 @@
+import os
+import subprocess
+from optimizer import ImageOptimizer
+
+
+def test_optimize_png(monkeypatch, tmp_path):
+    recorded = {}
+    def fake_run(cmd, capture_output=True, text=True):
+        recorded['cmd'] = cmd
+        class R:
+            returncode = 0
+            stderr = ''
+        return R()
+    monkeypatch.setattr(subprocess, 'run', fake_run)
+
+    file = tmp_path / 'img.png'
+    file.write_bytes(b'data')
+    opt = ImageOptimizer('optipng', 'cwebp')
+    log = opt.optimize_file(str(file))
+    assert recorded['cmd'] == ['optipng', '-o7', str(file)]
+    assert 'PNG optimisé' in log
+
+
+def test_optimize_webp(monkeypatch, tmp_path):
+    cmds = []
+    def fake_run(cmd, capture_output=True, text=True):
+        cmds.append(cmd)
+        class R:
+            returncode = 0
+            stderr = ''
+        return R()
+    monkeypatch.setattr(subprocess, 'run', fake_run)
+    replaced = []
+    monkeypatch.setattr(os, 'replace', lambda a, b: replaced.append((a, b)))
+
+    file = tmp_path / 'img.webp'
+    file.write_bytes(b'')
+    opt = ImageOptimizer('optipng', 'cwebp')
+    log = opt.optimize_file(str(file))
+    tmpfile = str(file) + '.tmp.webp'
+    assert cmds[0] == ['cwebp', '-lossless', str(file), '-o', tmpfile]
+    assert replaced and replaced[0] == (tmpfile, str(file))
+    assert 'WebP optimisé' in log
+
+
+def test_optimize_unsupported(tmp_path):
+    file = tmp_path / 'img.gif'
+    file.write_bytes(b'')
+    opt = ImageOptimizer('optipng', 'cwebp')
+    log = opt.optimize_file(str(file))
+    assert 'Format non supporté' in log


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow running pytest
- include pytest under development dependencies
- create sample HTML test data
- test scraper parsing logic, helper functions and image optimizer
- document how to run the tests locally and show CI badge

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6841e41cb1e083308498a709238c2f36