### PR TITLE
Add packaging and Docker build support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.10-slim
+WORKDIR /app
+COPY . /app
+RUN pip install --no-cache-dir .
+CMD ["python", "Application.py"]

--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@
 - Python 3.10 or newer.
 - Google Chrome. The ChromeDriver binary is downloaded automatically at runtime if `CHROME_DRIVER_PATH` is empty.
 
-Install the Python dependencies using:
+Install the project using:
 
 ```bash
-pip install -r requirements.txt
+pip install .
 ```
 
 If you plan to use asynchronous scraping, also install the
@@ -21,14 +21,30 @@ playwright install
 ### Quick Start
 
 ```bash
-pip install -r requirements.txt
+pip install .
 python Application.py
 ```
+
+### Other Installation Options
+
+- **Docker**
+
+  ```bash
+  docker build -t woocommerce-scraper .
+  docker run --rm woocommerce-scraper
+  ```
+
+- **Standalone Executable**
+
+  ```bash
+  ./build.sh
+  dist/woocommerce-scraper --help
+  ```
 
 ### Running Tests
 
 ```bash
-pip install -r requirements.txt
+pip install .[test]
 pytest
 ```
 

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -euo pipefail
+pyinstaller --onefile --name woocommerce-scraper cli.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,16 @@ dependencies = [
     "playwright",
 ]
 
+[project.optional-dependencies]
+test = [
+    "pytest",
+]
+
 [project.scripts]
 woocommerce-scraper = "cli:main"
+woocommerce-scraper-gui = "Application:main"
+
+[build-system]
+requires = ["setuptools>=42", "wheel"]
+build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
## Summary
- add pyproject entries for scripts, build-system and test extras
- document pip install, Docker usage and standalone build in README
- provide Dockerfile for running the application
- add `build.sh` to build a PyInstaller executable

## Testing
- `pip install .[test]` *(fails: Could not find a version that satisfies the requirement setuptools>=42)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6841e8be1ce08330a9282d4fdbb30be9