### PR TITLE
Centralize theme handling

### DIFF
--- a/ui/base_window.py
+++ b/ui/base_window.py
@@ -38,6 +38,7 @@ from PySide6.QtWidgets import (
     QInputDialog,
     QGraphicsOpacityEffect,
 )
+from ui.style import apply_theme
 from scraper_woocommerce import ScraperCore
 from optimizer import ImageOptimizer
 import config
@@ -325,36 +326,8 @@ class MainWindow(QMainWindow):
         self.btn_api.clicked.connect(lambda: self.stack.setCurrentWidget(self.page_api))
         self.btn_settings.clicked.connect(lambda: self.stack.setCurrentWidget(self.page_settings))
 
-        # Dark theme
-        self.setStyleSheet(
-            """
-            QWidget {
-                background-color: #121212;
-                color: #f5f5f5;
-                font-size: 14px;
-            }
-            QPushButton {
-                background-color: #1e1e1e;
-                border: 1px solid #333;
-                padding: 8px 12px;
-            }
-            QPushButton:hover {
-                background-color: #2b2b2b;
-            }
-            QLineEdit, QSpinBox {
-                background-color: #1e1e1e;
-                border: 1px solid #333;
-                padding: 4px;
-            }
-            QTextEdit {
-                background-color: #1e1e1e;
-                color: #f5f5f5;
-            }
-            QCheckBox {
-                padding: 2px;
-            }
-            """
-        )
+        # Apply centralized theme
+        apply_theme(self)
 
     def _create_scraper_page(self):
         page = QWidget()

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -7,6 +7,7 @@ from PySide6.QtCore import Qt
 from PySide6.QtGui import QIcon
 
 from ui.base_window import MainWindow
+from ui.style import apply_theme
 
 
 class DashboardWindow(MainWindow):
@@ -92,18 +93,8 @@ class DashboardWindow(MainWindow):
 
         self.sidebar.currentRowChanged.connect(self.stack.setCurrentIndex)
 
-        # Modern dark theme -------------------------------------------
-        self.setStyleSheet(
-            """
-            #Header {background-color: #2d2d2d; color: white;}
-            #Sidebar {background-color: #333; border: none; color: white;}
-            QListWidget::item {padding: 8px; margin: 2px; border-radius: 6px;}
-            QListWidget::item:selected {background: #555;}
-            QFrame[card="true"] {background: #414141; border-radius: 8px; padding: 16px;}
-            QPushButton {background: #555; color: white; border: none; padding: 8px; border-radius: 6px;}
-            QPushButton:hover {background: #666;}
-            """
-        )
+        # Apply centralized theme
+        apply_theme(self)
 
     # ------------------------------------------------------------------
     def _create_dashboard_page(self):

--- a/ui/style.py
+++ b/ui/style.py
@@ -1,0 +1,95 @@
+# Color constants
+SIDEBAR_DARK = "#23272F"
+PRIMARY_BLUE = "#3386FF"
+BACKGROUND_DARK = "#121212"
+SURFACE_DARK = "#1e1e1e"
+HOVER_DARK = "#2b2b2b"
+TEXT_LIGHT = "#f5f5f5"
+BORDER_DARK = "#333"
+
+BACKGROUND_LIGHT = "#ffffff"
+SURFACE_LIGHT = "#f0f0f0"
+TEXT_DARK = "#000000"
+BORDER_LIGHT = "#ccc"
+HOVER_LIGHT = "#e0e0e0"
+
+# Dark and light theme QSS
+DARK_THEME = f"""
+QWidget {{
+    background-color: {BACKGROUND_DARK};
+    color: {TEXT_LIGHT};
+    font-size: 14px;
+}}
+QPushButton {{
+    background: {PRIMARY_BLUE};
+    color: white;
+    border: none;
+    padding: 8px 12px;
+    border-radius: 4px;
+}}
+QPushButton:hover {{
+    background: {HOVER_DARK};
+}}
+QLineEdit, QSpinBox {{
+    background-color: {SURFACE_DARK};
+    border: 1px solid {BORDER_DARK};
+    padding: 4px;
+}}
+QTextEdit {{
+    background-color: {SURFACE_DARK};
+    color: {TEXT_LIGHT};
+}}
+#Sidebar {{
+    background-color: {SIDEBAR_DARK};
+    border: none;
+    color: white;
+}}
+QListWidget::item {{padding: 8px; margin: 2px; border-radius: 6px;}}
+QListWidget::item:selected {{background: {PRIMARY_BLUE};}}
+QFrame[card="true"] {{background: #414141; border-radius: 8px; padding: 16px;}}
+"""
+
+LIGHT_THEME = f"""
+QWidget {{
+    background-color: {BACKGROUND_LIGHT};
+    color: {TEXT_DARK};
+    font-size: 14px;
+}}
+QPushButton {{
+    background: {PRIMARY_BLUE};
+    color: white;
+    border: none;
+    padding: 8px 12px;
+    border-radius: 4px;
+}}
+QPushButton:hover {{
+    background: {HOVER_LIGHT};
+}}
+QLineEdit, QSpinBox {{
+    background-color: {SURFACE_LIGHT};
+    border: 1px solid {BORDER_LIGHT};
+    padding: 4px;
+}}
+QTextEdit {{
+    background-color: {SURFACE_LIGHT};
+    color: {TEXT_DARK};
+}}
+#Sidebar {{
+    background-color: {SIDEBAR_DARK};
+    border: none;
+    color: white;
+}}
+QListWidget::item {{padding: 8px; margin: 2px; border-radius: 6px;}}
+QListWidget::item:selected {{background: {PRIMARY_BLUE};}}
+QFrame[card="true"] {{background: #eee; border-radius: 8px; padding: 16px;}}
+"""
+
+THEMES = {
+    "dark": DARK_THEME,
+    "light": LIGHT_THEME,
+}
+
+def apply_theme(widget, theme="dark"):
+    """Apply the selected theme to the given widget."""
+    qss = THEMES.get(theme, "")
+    widget.setStyleSheet(qss)


### PR DESCRIPTION
## Summary
- centralize color palette in `ui/style.py`
- apply global theme via `apply_theme()` helper
- remove inline `setStyleSheet` calls

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6842050e8e40833090bb667449e73029