### PR TITLE
Add configurable theme switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ LINKS_FILE_PATH = "/path/to/liens_clean.txt"
 OPTIPNG_PATH = "tools/optimizers/optipng.exe"
 CWEBP_PATH = "tools/optimizers/cwebp.exe"
 ROOT_FOLDER = "image"
+THEME = "dark"
 ```
 
 You can edit this file directly or use the **Settings** page in the GUI which
@@ -88,6 +89,7 @@ updates it automatically. The defaults mirror the previous behaviour:
   Defaults to `BASE_DIR/custom_suffixes.py`.
 * `LINKS_FILE_PATH` – text file listing product URLs. Defaults to
   `BASE_DIR/liens_clean.txt`.
+* `THEME` – either `dark` or `light`. Controls the application appearance.
 
 A minimal template file `custom_suffixes.example.py` is included in the
 repository. Copy it to `custom_suffixes.py` and edit it to provide your own

--- a/config.py
+++ b/config.py
@@ -15,11 +15,12 @@ CWEBP_PATH = _cfg["CWEBP_PATH"]
 SUFFIX_FILE_PATH = _cfg["SUFFIX_FILE_PATH"]
 LINKS_FILE_PATH = _cfg["LINKS_FILE_PATH"]
 ROOT_FOLDER = _cfg["ROOT_FOLDER"]
+THEME = _cfg["THEME"]
 
 
 def reload() -> Dict[str, str | None]:
     """Reload configuration from disk and update module globals."""
-    global BASE_DIR, CHROME_DRIVER_PATH, CHROME_BINARY_PATH, OPTIPNG_PATH, CWEBP_PATH, SUFFIX_FILE_PATH, LINKS_FILE_PATH, ROOT_FOLDER
+    global BASE_DIR, CHROME_DRIVER_PATH, CHROME_BINARY_PATH, OPTIPNG_PATH, CWEBP_PATH, SUFFIX_FILE_PATH, LINKS_FILE_PATH, ROOT_FOLDER, THEME
     _new = config_manager.load()
     BASE_DIR = _new["BASE_DIR"]
     CHROME_DRIVER_PATH = _new["CHROME_DRIVER_PATH"]
@@ -29,4 +30,5 @@ def reload() -> Dict[str, str | None]:
     SUFFIX_FILE_PATH = _new["SUFFIX_FILE_PATH"]
     LINKS_FILE_PATH = _new["LINKS_FILE_PATH"]
     ROOT_FOLDER = _new["ROOT_FOLDER"]
+    THEME = _new["THEME"]
     return _new

--- a/config_manager.py
+++ b/config_manager.py
@@ -16,6 +16,7 @@ DEFAULTS = {
     "SUFFIX_FILE_PATH": os.path.join(_DEFAULT_BASE, "custom_suffixes.py"),
     "LINKS_FILE_PATH": os.path.join(_DEFAULT_BASE, "liens_clean.txt"),
     "ROOT_FOLDER": "image",
+    "THEME": "dark",
 }
 
 

--- a/ui/base_window.py
+++ b/ui/base_window.py
@@ -317,7 +317,7 @@ class MainWindow(QMainWindow):
         self.sidebar.currentRowChanged.connect(lambda i: self.stack.setCurrentWidget(pages[i]))
 
         # Apply centralized theme
-        apply_theme(self)
+        apply_theme(self, config.THEME)
 
     def _create_scraper_page(self):
         page = QWidget()

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -6,6 +6,7 @@ from PySide6.QtWidgets import (
     QListWidgetItem,
     QLabel,
     QLineEdit,
+    QCheckBox,
     QStackedLayout,
     QStyle,
     QFrame,
@@ -20,6 +21,8 @@ from ui import style
 from ui.base_window import MainWindow
 from ui.style import apply_theme
 from ui.responsive import ResponsiveMixin
+import config
+import config_manager
 
 
 def _get_project_info():
@@ -61,6 +64,10 @@ class DashboardWindow(ResponsiveMixin, MainWindow):
         self.header_layout.addWidget(self.label_welcome)
         self.header_layout.addStretch(1)
         self.header_layout.addWidget(self.edit_search)
+        self.cb_dark_theme = QCheckBox("Th\u00e8me sombre")
+        self.cb_dark_theme.setChecked(config.THEME == "dark")
+        self.cb_dark_theme.stateChanged.connect(self._toggle_theme)
+        self.header_layout.addWidget(self.cb_dark_theme)
         main_layout.addWidget(header)
 
         # Body ---------------------------------------------------------
@@ -135,7 +142,7 @@ class DashboardWindow(ResponsiveMixin, MainWindow):
         main_layout.addWidget(footer)
 
         # Apply centralized theme
-        apply_theme(self)
+        apply_theme(self, config.THEME)
 
     # ------------------------------------------------------------------
     def _create_dashboard_page(self):
@@ -202,3 +209,12 @@ class DashboardWindow(ResponsiveMixin, MainWindow):
             self.sidebar.collapse()
         else:
             self.sidebar.expand()
+
+    # ------------------------------------------------------------------
+    def _toggle_theme(self, state=None):
+        theme = "dark" if self.cb_dark_theme.isChecked() else "light"
+        apply_theme(self, theme)
+        data = config_manager.load()
+        data["THEME"] = theme
+        config_manager.save(data)
+        config.reload()


### PR DESCRIPTION
## Summary
- support storing theme preference in config
- apply theme from config at startup
- add checkbox in dashboard header to toggle dark/light modes
- document THEME setting in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68420ab7ca148330b732926bcb07c51a