### PR TITLE
Add advanced image sidebar entry

### DIFF
--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -86,6 +86,7 @@ class DashboardWindow(ResponsiveMixin, MainWindow):
             ("Accueil", QStyle.SP_DesktopIcon),
             ("Scraper", QStyle.SP_FileIcon),
             ("Scraping d'image", QStyle.SP_DirIcon),
+            ("Scraping d'images avancé", QStyle.SP_DirIcon),
             ("Images avancées", QStyle.SP_DirIcon),
             ("Sélecteur visuel", QStyle.SP_DialogOpenButton),
             ("Optimiseur d'images", QStyle.SP_ComputerIcon),


### PR DESCRIPTION
## Summary
- add new sidebar label "Scraping d'images avancé"
- instantiate the advanced image scraping page (already done) and add it to the stack

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684214fd524c833099919a4da609be73