### PR TITLE
Fix missing QListWidgetItem import

### DIFF
--- a/ui/components.py
+++ b/ui/components.py
@@ -1,6 +1,7 @@
 from PySide6.QtWidgets import (
     QPushButton,
     QListWidget,
+    QListWidgetItem,
     QFrame,
     QGraphicsDropShadowEffect,
     QWidget,


### PR DESCRIPTION
## Summary
- add `QListWidgetItem` to the import block in `ui/components.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for pandas and others)*

------
https://chatgpt.com/codex/tasks/task_e_68427a8c93a88330a81835804376bd4a