### PR TITLE
Audit fixes

### DIFF
--- a/AUDIT_REPORT.md
+++ b/AUDIT_REPORT.md
@@ -1,0 +1,12 @@
+# Audit Report
+
+## Summary
+- Verified repository structure: includes CLI, GUI, scraping, optimization and Flask API modules with tests.
+- Detected failing tests due to missing PySide6 shared libraries when importing `scraper_woocommerce`.
+- Patched `scraper_woocommerce.py` to load `QImage` conditionally and provide a minimal stub when PySide6 is absent.
+- All tests now pass using `PYTHONPATH=$PWD pytest -q`.
+
+## Recommendations
+- Package layout is flat; `pip install -e .` fails. Define explicit packages in `pyproject.toml` if distribution is required.
+- Consider adding `pytest-asyncio` to test dependencies to run async tests without warnings.
+- Document the need to set `PYTHONPATH` or install as package when running tests.

--- a/scraper_woocommerce.py
+++ b/scraper_woocommerce.py
@@ -14,7 +14,27 @@ import logging
 from logging import getLogger
 from playwright.async_api import async_playwright
 import hashlib
-from PySide6.QtGui import QImage
+try:
+    from PySide6.QtGui import QImage  # type: ignore
+except Exception:  # pragma: no cover - optional dependency may be missing
+    class QImage:  # minimal stub used when PySide6 is unavailable
+        def __init__(self, path):
+            self._w = 0
+            self._h = 0
+            try:
+                import struct
+                with open(path, 'rb') as f:
+                    header = f.read(24)
+                if header.startswith(b'\x89PNG'):
+                    self._w, self._h = struct.unpack('>II', header[16:24])
+            except Exception:
+                pass
+
+        def width(self):
+            return self._w
+
+        def height(self):
+            return self._h
 import config
 import logger_setup  # noqa: F401  # configure logging
 import storage


### PR DESCRIPTION
## Summary
- make PySide6 optional for headless test environments
- add an audit report

## Testing
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68429e8186488330aaf81f5dc0551208