### PR TITLE
Ajout d'un module de comptabilité

### DIFF
--- a/accounting/README.md
+++ b/accounting/README.md
@@ -1,0 +1,24 @@
+# Module de comptabilité
+
+Ce dossier contient une implémentation minimale permettant de gérer des 
+transactions comptables simples. La structure est conçue pour être 
+étendue ultérieurement avec des fonctions d'import, de reporting et de 
+rapprochement.
+
+## Fichiers
+
+- `transaction.py` : classe `Transaction` représentant une opération
+  comptable basique.
+- `account.py` : classe `Account` pour manipuler des comptes et calculer
+  leur solde.
+- `journal_entry.py` : classe `JournalEntry` correspondant aux lignes
+  d'écriture liées aux transactions.
+- `storage.py` : abstractions de stockage avec une implémentation en
+  mémoire (`InMemoryStorage`). Ce système pourra être adapté pour
+  utiliser SQLite ou des fichiers CSV.
+- `__init__.py` : expose les classes principales du module.
+
+Les données sont pour l'instant conservées en mémoire via des listes
+mais la couche `BaseStorage` prévoit l'intégration future d'autres
+backends de persistance.
+

--- a/accounting/__init__.py
+++ b/accounting/__init__.py
@@ -1,0 +1,20 @@
+"""Module de comptabilité.
+
+Ce module fournit des classes de base pour gérer des opérations
+comptables simples. Les données sont stockées en mémoire mais une
+abstraction prépare l'utilisation d'autres backends comme SQLite ou CSV.
+"""
+
+from .transaction import Transaction
+from .account import Account
+from .journal_entry import JournalEntry
+from .storage import BaseStorage, InMemoryStorage
+
+__all__ = [
+    "Transaction",
+    "Account",
+    "JournalEntry",
+    "BaseStorage",
+    "InMemoryStorage",
+]
+

--- a/accounting/account.py
+++ b/accounting/account.py
@@ -1,0 +1,29 @@
+"""Gestion des comptes comptables."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List
+
+from .journal_entry import JournalEntry
+
+
+@dataclass
+class Account:
+    """Un compte comptable."""
+
+    code: str
+    nom: str
+    entries: List[JournalEntry] = field(default_factory=list)
+
+    def ajouter_ecriture(self, entry: JournalEntry) -> None:
+        """Ajoute une écriture au compte."""
+        self.entries.append(entry)
+
+    @property
+    def solde(self) -> float:
+        """Calcule le solde du compte."""
+        debit = sum(e.debit for e in self.entries)
+        credit = sum(e.credit for e in self.entries)
+        return debit - credit
+

--- a/accounting/journal_entry.py
+++ b/accounting/journal_entry.py
@@ -1,0 +1,18 @@
+"""Ecritures comptables."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class JournalEntry:
+    """Ligne d'écriture liée à une transaction."""
+
+    transaction_id: str
+    account_code: str
+    debit: float = 0.0
+    credit: float = 0.0
+    description: Optional[str] = None
+

--- a/accounting/storage.py
+++ b/accounting/storage.py
@@ -1,0 +1,66 @@
+"""Abstractions de stockage pour les données comptables."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import List
+
+from .transaction import Transaction
+from .account import Account
+from .journal_entry import JournalEntry
+
+
+class BaseStorage(ABC):
+    """Interface de stockage des données comptables."""
+
+    @abstractmethod
+    def add_account(self, account: Account) -> None:
+        """Sauvegarde un compte."""
+
+    @abstractmethod
+    def add_transaction(self, tx: Transaction) -> None:
+        """Sauvegarde une transaction."""
+
+    @abstractmethod
+    def add_entry(self, entry: JournalEntry) -> None:
+        """Sauvegarde une écriture."""
+
+    @abstractmethod
+    def list_accounts(self) -> List[Account]:
+        """Retourne tous les comptes."""
+
+    @abstractmethod
+    def list_transactions(self) -> List[Transaction]:
+        """Retourne toutes les transactions."""
+
+    @abstractmethod
+    def list_entries(self) -> List[JournalEntry]:
+        """Retourne toutes les écritures."""
+
+
+class InMemoryStorage(BaseStorage):
+    """Implémentation en mémoire simple."""
+
+    def __init__(self) -> None:
+        self._accounts: List[Account] = []
+        self._transactions: List[Transaction] = []
+        self._entries: List[JournalEntry] = []
+
+    def add_account(self, account: Account) -> None:
+        self._accounts.append(account)
+
+    def add_transaction(self, tx: Transaction) -> None:
+        self._transactions.append(tx)
+
+    def add_entry(self, entry: JournalEntry) -> None:
+        self._entries.append(entry)
+
+    def list_accounts(self) -> List[Account]:
+        return list(self._accounts)
+
+    def list_transactions(self) -> List[Transaction]:
+        return list(self._transactions)
+
+    def list_entries(self) -> List[JournalEntry]:
+        return list(self._entries)
+

--- a/accounting/transaction.py
+++ b/accounting/transaction.py
@@ -1,0 +1,23 @@
+"""Classes et fonctions concernant les opérations comptables."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from typing import Optional
+
+
+@dataclass
+class Transaction:
+    """Représente une opération comptable de base."""
+
+    date: date
+    description: str
+    montant: float
+    debit: str
+    credit: str
+
+    def __post_init__(self) -> None:
+        if self.montant < 0:
+            raise ValueError("Le montant doit être positif")
+


### PR DESCRIPTION
## Notes
Les tests échouent car certaines dépendances comme `pandas` ou `scraper_woocommerce` ne sont pas disponibles dans l'environnement.

## Summary
- création du dossier `accounting`
- ajout des classes `Transaction`, `Account` et `JournalEntry`
- abstraction de stockage avec `BaseStorage` et `InMemoryStorage`
- fichier `__init__.py` exposant les objets du module
- documentation du module en français

------
https://chatgpt.com/codex/tasks/task_e_6842a203d8908330b99a08badf440b02