### PR TITLE
Add bank statement import

### DIFF
--- a/accounting/__init__.py
+++ b/accounting/__init__.py
@@ -9,6 +9,7 @@ from .transaction import Transaction
 from .account import Account
 from .journal_entry import JournalEntry
 from .storage import BaseStorage, InMemoryStorage
+from .bank_import import import_releve
 
 __all__ = [
     "Transaction",
@@ -16,5 +17,6 @@ __all__ = [
     "JournalEntry",
     "BaseStorage",
     "InMemoryStorage",
+    "import_releve",
 ]
 

--- a/accounting/bank_import.py
+++ b/accounting/bank_import.py
@@ -1,0 +1,81 @@
+"""Importation de relevés bancaires au format CSV ou Excel."""
+
+from __future__ import annotations
+
+import logging
+import os
+import unicodedata
+from typing import List
+
+import pandas as pd
+
+from .transaction import Transaction
+from .storage import BaseStorage
+
+
+def _norm(text: str) -> str:
+    """Normalise un texte (minuscules, sans accents)."""
+    tmp = unicodedata.normalize("NFKD", text)
+    tmp = "".join(c for c in tmp if not unicodedata.combining(c))
+    return tmp.lower().strip()
+
+
+def import_releve(path: str, storage: BaseStorage | None = None) -> List[Transaction]:
+    """Lit un relevé bancaire et retourne une liste de :class:`Transaction`.
+
+    Le fichier peut être au format CSV ou Excel. En option, un objet
+    :class:`BaseStorage` peut être passé pour enregistrer automatiquement
+    les transactions importées.
+    """
+    try:
+        if not os.path.isfile(path):
+            raise FileNotFoundError(path)
+        ext = os.path.splitext(path)[1].lower()
+        if ext == ".csv":
+            df = pd.read_csv(path)
+        elif ext in [".xls", ".xlsx"]:
+            df = pd.read_excel(path)
+        else:
+            raise ValueError("Format de fichier non supporté")
+    except FileNotFoundError:
+        logging.error("Fichier introuvable: %s", path)
+        raise ValueError(f"Fichier introuvable: {path}") from None
+    except Exception as e:  # lecture/parse errors
+        logging.error("Erreur lors de la lecture de %s : %s", path, e)
+        raise ValueError(f"Erreur lors de la lecture du fichier {path} : {e}") from None
+
+    # normaliser les noms de colonnes
+    col_map = { _norm(c): c for c in df.columns }
+    required = ["date", "libelle", "montant", "type"]
+    missing = [c for c in required if c not in col_map]
+    if missing:
+        logging.error("Colonnes manquantes: %s", ", ".join(missing))
+        raise ValueError("Colonnes manquantes : " + ", ".join(missing))
+
+    df = df.rename(columns={ col_map[k]: k for k in required })
+
+    txs: List[Transaction] = []
+    for _, row in df.iterrows():
+        try:
+            dt = pd.to_datetime(row["date"]).date()
+        except Exception as e:
+            logging.error("Date invalide %s: %s", row.get("date"), e)
+            raise ValueError(f"Date invalide : {row.get('date')}") from None
+        desc = str(row["libelle"]) if not pd.isna(row["libelle"]) else ""
+        montant = float(row["montant"])
+        type_val = _norm(str(row["type"]))
+        if type_val.startswith("debit"):
+            tx = Transaction(dt, desc, montant, debit="BANQUE", credit="")
+        elif type_val.startswith("credit"):
+            tx = Transaction(dt, desc, montant, debit="", credit="BANQUE")
+        else:
+            logging.error("Type invalide: %s", row["type"])
+            raise ValueError(f"Type invalide : {row['type']}")
+        txs.append(tx)
+        if storage:
+            try:
+                storage.add_transaction(tx)
+            except Exception as e:
+                logging.error("Erreur lors de l'enregistrement: %s", e)
+                raise
+    return txs

--- a/tests/test_bank_import.py
+++ b/tests/test_bank_import.py
@@ -1,0 +1,33 @@
+import pandas as pd
+import pytest
+
+from accounting import import_releve, InMemoryStorage
+
+
+def test_import_releve_csv(tmp_path):
+    # create sample csv
+    data = pd.DataFrame({
+        'Date': ['2023-01-01', '2023-01-02'],
+        'Libellé': ['Achat', 'Virement'],
+        'Montant': [10.5, 20.0],
+        'Type': ['débit', 'crédit'],
+    })
+    csv_path = tmp_path / 'releve.csv'
+    data.to_csv(csv_path, index=False)
+
+    storage = InMemoryStorage()
+    txs = import_releve(str(csv_path), storage)
+
+    assert len(txs) == 2
+    assert txs[0].debit == 'BANQUE'
+    assert txs[1].credit == 'BANQUE'
+    # storage should contain same transactions
+    assert len(storage.list_transactions()) == 2
+
+
+def test_import_releve_missing_col(tmp_path):
+    df = pd.DataFrame({'Date': ['2023-01-01']})
+    path = tmp_path / 'bad.csv'
+    df.to_csv(path, index=False)
+    with pytest.raises(ValueError):
+        import_releve(str(path))


### PR DESCRIPTION
## Summary
- implement bank statement import utility that handles CSV and Excel files
- expose the new function from the accounting package
- test importing a simple bank statement

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842a5ab2cec83308ee73bc396402020