### PR TITLE
Add accounting import help

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ dist/
 
 # Other
 .DS_Store
+logs/

--- a/accounting/HELP.md
+++ b/accounting/HELP.md
@@ -1,0 +1,32 @@
+# Aide sur l'import du journal
+
+Ce document explique comment mettre en forme votre fichier bancaire et comment l'importer dans la page **Journal** de l'application.
+
+## Format du fichier
+
+Le fichier doit comporter au minimum les colonnes suivantes :
+
+- **date** : date de l'opération (formats reconnus par pandas, par exemple `AAAA-MM-JJ`).
+- **libellé** : description de l'écriture.
+- **montant** : montant numérique de l'opération.
+- **type** : indique s'il s'agit d'un "débit" ou d'un "crédit".
+
+La détection des noms de colonnes est insensible à la casse et aux accents. Les autres colonnes sont ignorées.
+
+## Importer un relevé
+
+1. Ouvrez la page **Journal** depuis la barre latérale.
+2. Cliquez sur le bouton **Importer relevé…** situé en haut de la page.
+3. Sélectionnez un fichier CSV ou Excel contenant les colonnes ci-dessus.
+4. Les lignes valides sont ajoutées au tableau.
+
+## Filtres disponibles
+
+Sous le bouton d'import se trouvent plusieurs champs permettant de filtrer le journal :
+
+- **Du / au** : limites de dates.
+- **Libellé contient…** : texte à rechercher dans la colonne libellé.
+- **Min / Max** : plage de montants.
+- **Type** : tous, seulement les débits ou seulement les crédits.
+
+Les filtres s'appliquent immédiatement lors de la modification des champs.

--- a/accounting/README.md
+++ b/accounting/README.md
@@ -22,3 +22,5 @@ Les données sont pour l'instant conservées en mémoire via des listes
 mais la couche `BaseStorage` prévoit l'intégration future d'autres
 backends de persistance.
 
+
+Pour plus de détails sur l'import des relevés et l'utilisation des filtres du journal, consultez le fichier [HELP.md](HELP.md).


### PR DESCRIPTION
## Summary
- add step-by-step guide to import bank statements in `accounting/HELP.md`
- reference the help file from the accounting README
- ignore generated log files

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842aa06f1848330afdbba800a108feb