### PR TITLE
Ajout de tests pour le reporting comptable

### DIFF
--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -29,6 +29,20 @@ def test_export_transactions_csv(tmp_path):
     assert set(["date", "description", "montant"]).issubset(df.columns)
 
 
+def test_export_transactions_xlsx(tmp_path):
+    txs = [
+        Transaction(date(2023, 1, 1), "Achat", 50.0, debit="401", credit=""),
+        Transaction(date(2023, 1, 2), "Vente", 120.0, debit="", credit="701"),
+    ]
+    path = tmp_path / "tx.xlsx"
+    export_transactions(txs, path)
+
+    assert path.exists()
+    df = pd.read_excel(path)
+    assert len(df) == 2
+    assert set(["date", "description", "montant"]).issubset(df.columns)
+
+
 def test_export_entries_xlsx(tmp_path):
     entries = [
         JournalEntry("1", "701", debit=100.0, date=date(2023, 1, 1)),
@@ -41,6 +55,41 @@ def test_export_entries_xlsx(tmp_path):
     df = pd.read_excel(path)
     assert len(df) == 2
     assert set(["transaction_id", "account_code"]).issubset(df.columns)
+
+
+def test_export_entries_csv(tmp_path):
+    entries = [
+        JournalEntry("1", "701", debit=100.0, date=date(2023, 1, 1)),
+        JournalEntry("2", "602", credit=80.0, date=date(2023, 1, 2)),
+    ]
+    path = tmp_path / "entries.csv"
+    export_entries(entries, path)
+
+    assert path.exists()
+    df = pd.read_csv(path)
+    assert len(df) == 2
+    assert set(["transaction_id", "account_code"]).issubset(df.columns)
+
+
+def test_grand_livre_and_balance_values():
+    entries = [
+        JournalEntry("1", "601", debit=50.0, date=date(2023, 1, 1)),
+        JournalEntry("2", "701", credit=20.0, date=date(2023, 1, 2)),
+        JournalEntry("3", "601", debit=30.0, date=date(2023, 1, 3)),
+    ]
+    ledger_df = grand_livre(entries)
+    assert list(ledger_df["account_code"]) == ["601", "601", "701"]
+
+    balance_df = balance(entries)
+    balance_df["account_code"] = balance_df["account_code"].astype(str)
+    bal_601 = balance_df.loc[balance_df["account_code"] == "601"].iloc[0]
+    bal_701 = balance_df.loc[balance_df["account_code"] == "701"].iloc[0]
+    assert bal_601["debit"] == 80.0
+    assert bal_601["credit"] == 0.0
+    assert bal_601["solde"] == 80.0
+    assert bal_701["debit"] == 0.0
+    assert bal_701["credit"] == 20.0
+    assert bal_701["solde"] == -20.0
 
 
 def test_export_invalid_extension(tmp_path):
@@ -86,6 +135,7 @@ def test_export_report_pdf(tmp_path):
     path = tmp_path / "report.pdf"
     export_report_pdf(ledger_df, balance_df, cat_df, path)
     assert path.exists()
+    assert path.stat().st_size > 0
     with open(path, "rb") as f:
         header = f.read(4)
     assert header.startswith(b"%PDF")


### PR DESCRIPTION
## Notes
- Ajout de tests couvrant `export_transactions` en CSV et XLSX ainsi que `export_entries` en CSV et XLSX
- Vérification détaillée des fonctions `grand_livre` et `balance`
- Contrôle de la génération du rapport PDF et des CSV

## Testing
- `python -m pytest tests/test_reporting.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6842b7317464833080cd0f9f3e998786