### PR TITLE
Improve journal table styling

### DIFF
--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -308,6 +308,7 @@ class DashboardWindow(ResponsiveMixin, MainWindow):
             ["Date", "Libellé", "Montant", "Débit", "Crédit", "Catégorie", "État"]
         )
         self.table_journal.itemChanged.connect(self._on_cat_changed)
+        style.style_table_widget(self.table_journal, config.THEME)
         layout.addWidget(self.table_journal)
 
         for w in [
@@ -618,6 +619,7 @@ class DashboardWindow(ResponsiveMixin, MainWindow):
     def _toggle_theme(self, state=None):
         theme = "dark" if self.cb_dark_theme.isChecked() else "light"
         apply_theme(self, theme)
+        style.style_table_widget(self.table_journal, theme)
         data = config_manager.load()
         data["THEME"] = theme
         config_manager.save(data)

--- a/ui/style.py
+++ b/ui/style.py
@@ -113,3 +113,17 @@ def style_progress_bar(bar):
         "QProgressBar {border:1px solid #444; border-radius:8px; text-align:center; height:25px;}"
         f"QProgressBar::chunk {{background-color:{PRIMARY_BLUE}; border-radius:8px;}}"
     )
+
+
+def style_table_widget(table, theme="dark"):
+    """Apply consistent styling to table widgets for dark/light themes."""
+    if theme == "dark":
+        table.setStyleSheet(
+            f"QTableWidget {{background-color:{SURFACE_DARK}; color:{TEXT_LIGHT}; gridline-color:{BORDER_DARK};}}"
+            f"QHeaderView::section {{background-color:{SIDEBAR_DARK}; color:{TEXT_LIGHT}; border:1px solid {BORDER_DARK}; padding:4px;}}"
+        )
+    else:
+        table.setStyleSheet(
+            f"QTableWidget {{background-color:{BACKGROUND_LIGHT}; color:{TEXT_DARK}; gridline-color:{BORDER_LIGHT};}}"
+            f"QHeaderView::section {{background-color:{SURFACE_LIGHT}; color:{TEXT_DARK}; border:1px solid {BORDER_LIGHT}; padding:4px;}}"
+        )


### PR DESCRIPTION
## Summary
- style QTableWidget and header for dark/light themes
- apply table styling when creating the journal table
- update theme toggle to restyle the table

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'accounting')*

------
https://chatgpt.com/codex/tasks/task_e_6842bd6136648330a1f5255dfbe3b422