### PR TITLE
Add dedicated accounting error log file

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,8 @@ The server listens on port `5000` by default.
 
 ## Logging
 All console output is also written to `logs/app.log` at the repository root. The
-file rotates automatically when it reaches about 1 MB.
+file rotates automatically when it reaches about 1 MB. Errors coming from the
+`accounting` package are additionally stored in `logs/compta_errors.log`.
 
 ## Resuming a Scrape
 During scraping, progress is stored in `scraping_checkpoint.json` inside

--- a/logger_setup.py
+++ b/logger_setup.py
@@ -5,6 +5,7 @@ from logging.handlers import RotatingFileHandler
 LOG_DIR = os.path.join(os.path.dirname(__file__), "logs")
 os.makedirs(LOG_DIR, exist_ok=True)
 LOG_FILE = os.path.join(LOG_DIR, "app.log")
+ERROR_LOG_FILE = os.path.join(LOG_DIR, "compta_errors.log")
 
 handler = RotatingFileHandler(LOG_FILE, maxBytes=1_000_000, backupCount=3, encoding="utf-8")
 logging.basicConfig(
@@ -12,3 +13,12 @@ logging.basicConfig(
     format="%(asctime)s [%(levelname)s] %(message)s",
     handlers=[handler, logging.StreamHandler()]
 )
+
+# Dedicated handler for accounting errors
+accounting_errors_handler = RotatingFileHandler(
+    ERROR_LOG_FILE, maxBytes=1_000_000, backupCount=3, encoding="utf-8"
+)
+accounting_errors_handler.setLevel(logging.ERROR)
+
+accounting_logger = logging.getLogger("accounting")
+accounting_logger.addHandler(accounting_errors_handler)


### PR DESCRIPTION
## Summary
- log accounting module errors to `logs/compta_errors.log`
- update documentation with new log location

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842c0bb212c8330a29c383faa34d60a