### PR TITLE
Introduce SQLAlchemy ORM backend

### DIFF
--- a/accounting/__init__.py
+++ b/accounting/__init__.py
@@ -8,7 +8,7 @@ abstraction prépare l'utilisation d'autres backends comme SQLite ou CSV.
 from .transaction import Transaction
 from .account import Account
 from .journal_entry import JournalEntry
-from .storage import BaseStorage, InMemoryStorage
+from .storage import BaseStorage, InMemoryStorage, SQLStorage
 from .bank_import import import_releve
 from .categorization import (
     categoriser_automatiquement,
@@ -38,6 +38,7 @@ __all__ = [
     "JournalEntry",
     "BaseStorage",
     "InMemoryStorage",
+    "SQLStorage",
     "import_releve",
     "categoriser_automatiquement",
     "rapport_par_categorie",

--- a/accounting/storage.py
+++ b/accounting/storage.py
@@ -5,6 +5,40 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import List
 
+from sqlalchemy import Column, String, Float, Date, ForeignKey
+
+from db import SessionLocal, engine
+from db.models import Base
+
+
+class AccountModel(Base):
+    __tablename__ = "accounts"
+    code = Column(String, primary_key=True)
+    nom = Column(String)
+
+
+class TransactionModel(Base):
+    __tablename__ = "transactions"
+    id = Column(String, primary_key=True)
+    date = Column(Date)
+    description = Column(String)
+    montant = Column(Float)
+    debit = Column(String)
+    credit = Column(String)
+    categorie = Column(String)
+    journal_entry_id = Column(String, ForeignKey("journal_entries.id"), nullable=True)
+
+
+class JournalEntryModel(Base):
+    __tablename__ = "journal_entries"
+    id = Column(String, primary_key=True)
+    transaction_id = Column(String, ForeignKey("transactions.id"))
+    account_code = Column(String, ForeignKey("accounts.code"))
+    debit = Column(Float, default=0.0)
+    credit = Column(Float, default=0.0)
+    description = Column(String, nullable=True)
+    date = Column(Date, nullable=True)
+
 from .transaction import Transaction
 from .account import Account
 from .journal_entry import JournalEntry
@@ -70,3 +104,86 @@ class InMemoryStorage(BaseStorage):
     def list_entries(self) -> List[JournalEntry]:
         """Retourne la liste des écritures enregistrées."""
         return list(self._entries)
+
+
+class SQLStorage(BaseStorage):
+    """Implémentation basée sur SQLAlchemy."""
+
+    def __init__(self) -> None:
+        Base.metadata.create_all(bind=engine)
+
+    def _session(self):
+        return SessionLocal()
+
+    def add_account(self, account: Account) -> None:
+        with self._session() as session:
+            obj = AccountModel(code=account.code, nom=account.nom)
+            session.merge(obj)
+            session.commit()
+
+    def add_transaction(self, tx: Transaction) -> None:
+        with self._session() as session:
+            obj = TransactionModel(
+                id=tx.id,
+                date=tx.date,
+                description=tx.description,
+                montant=tx.montant,
+                debit=tx.debit,
+                credit=tx.credit,
+                categorie=tx.categorie,
+                journal_entry_id=tx.journal_entry_id,
+            )
+            session.merge(obj)
+            session.commit()
+
+    def add_entry(self, entry: JournalEntry) -> None:
+        with self._session() as session:
+            obj = JournalEntryModel(
+                id=entry.id,
+                transaction_id=entry.transaction_id,
+                account_code=entry.account_code,
+                debit=entry.debit,
+                credit=entry.credit,
+                description=entry.description,
+                date=entry.date,
+            )
+            session.merge(obj)
+            session.commit()
+
+    def list_accounts(self) -> List[Account]:
+        with self._session() as session:
+            rows = session.query(AccountModel).all()
+            return [Account(code=r.code, nom=r.nom) for r in rows]
+
+    def list_transactions(self) -> List[Transaction]:
+        with self._session() as session:
+            rows = session.query(TransactionModel).all()
+            return [
+                Transaction(
+                    r.date,
+                    r.description,
+                    r.montant,
+                    r.debit,
+                    r.credit,
+                    categorie=r.categorie,
+                    id=r.id,
+                    journal_entry_id=r.journal_entry_id,
+                )
+                for r in rows
+            ]
+
+    def list_entries(self) -> List[JournalEntry]:
+        with self._session() as session:
+            rows = session.query(JournalEntryModel).all()
+            return [
+                JournalEntry(
+                    r.transaction_id,
+                    r.account_code,
+                    debit=r.debit,
+                    credit=r.credit,
+                    description=r.description,
+                    date=r.date,
+                    id=r.id,
+                )
+                for r in rows
+            ]

--- a/db/__init__.py
+++ b/db/__init__.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from pathlib import Path
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from .models import Base
+
+engine = None
+SessionLocal = sessionmaker(autocommit=False, autoflush=False)
+
+
+def init_engine(path: str | Path):
+    """Initialise the global engine and session factory."""
+    global engine, SessionLocal
+    engine = create_engine(f"sqlite:///{path}")
+    SessionLocal.configure(bind=engine)
+    return engine

--- a/db/models.py
+++ b/db/models.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from sqlalchemy.orm import declarative_base, relationship
+from sqlalchemy import Column, Integer, String, ForeignKey, DateTime, Text
+
+Base = declarative_base()
+
+class Product(Base):
+    __tablename__ = 'products'
+    product_id = Column(String, primary_key=True)
+    name = Column(String)
+    sku = Column(String)
+    price = Column(String)
+    dossier = Column(String)
+
+    variants = relationship('Variant', back_populates='product', cascade='all, delete-orphan')
+    competitors = relationship('Competitor', back_populates='product', cascade='all, delete-orphan')
+    images = relationship('Image', back_populates='product', cascade='all, delete-orphan')
+
+class Variant(Base):
+    __tablename__ = 'variants'
+    product_id = Column(String, ForeignKey('products.product_id'), primary_key=True)
+    sku = Column(String, primary_key=True)
+    name = Column(String)
+    price = Column(String)
+
+    product = relationship('Product', back_populates='variants')
+
+class Competitor(Base):
+    __tablename__ = 'competitors'
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    product_id = Column(String, ForeignKey('products.product_id'))
+    title = Column(String)
+    url = Column(String)
+    file_path = Column(String)
+    status = Column(String)
+
+    product = relationship('Product', back_populates='competitors')
+
+class Image(Base):
+    __tablename__ = 'images'
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    product_id = Column(String, ForeignKey('products.product_id'))
+    variant = Column(String)
+    url_competitor = Column(String)
+    filename = Column(String)
+    wordpress_link = Column(String)
+
+    product = relationship('Product', back_populates='images')
+
+class ScheduledTask(Base):
+    __tablename__ = 'scheduled_tasks'
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    name = Column(String)
+    scheduled_for = Column(DateTime)
+    status = Column(String)
+
+class Log(Base):
+    __tablename__ = 'logs'
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    created = Column(DateTime)
+    level = Column(String)
+    message = Column(Text)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "PySide6",
     "webdriver-manager",
     "playwright",
+    "SQLAlchemy",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ fpdf2
 PySide6
 webdriver-manager
 playwright
+SQLAlchemy
 
 # Development
 pytest

--- a/scraper_woocommerce.py
+++ b/scraper_woocommerce.py
@@ -38,6 +38,8 @@ except Exception:  # pragma: no cover - optional dependency may be missing
 import config
 import logger_setup  # noqa: F401  # configure logging
 import storage
+import db
+from pathlib import Path
 
 from selenium import webdriver
 from selenium.webdriver.chrome.service import Service
@@ -69,7 +71,8 @@ class ScraperCore:
         self.checkpoint_file = os.path.join(self.base_dir, "scraping_checkpoint.json")
 
         self.db_path = storage.db_path(self.base_dir)
-        storage.init_db(self.base_dir)
+        db.init_engine(Path(self.db_path))
+        storage.init_db()
 
         self._progress = 0
         self._logs = []

--- a/storage.py
+++ b/storage.py
@@ -1,115 +1,65 @@
+from __future__ import annotations
+
 import os
-import sqlite3
+from typing import List, Tuple
+
 import config
+import db
+from db import SessionLocal
+from db.models import Base, Product, Variant, Competitor
 
 
-def db_path(base_dir=None):
+def db_path(base_dir=None) -> str:
     base = base_dir or config.BASE_DIR
     return os.path.join(base, "scraper.db")
 
 
-def init_db(base_dir=None):
-    path = db_path(base_dir)
-    conn = sqlite3.connect(path)
-    cur = conn.cursor()
-    cur.execute(
-        """
-        CREATE TABLE IF NOT EXISTS products (
-            product_id TEXT PRIMARY KEY,
-            name TEXT,
-            sku TEXT,
-            price TEXT,
-            dossier TEXT
+def init_db() -> None:
+    """Create all tables bound to the current engine."""
+    Base.metadata.create_all(bind=db.engine)
+
+
+def _get_session():
+    return SessionLocal()
+
+
+def upsert_product(product_id: str, name: str, sku: str, price: str, dossier: str) -> None:
+    with _get_session() as session:
+        obj = session.get(Product, product_id)
+        if obj is None:
+            obj = Product(product_id=product_id)
+            session.add(obj)
+        obj.name = name
+        obj.sku = sku
+        obj.price = price
+        obj.dossier = dossier
+        session.commit()
+
+
+def upsert_variant(product_id: str, sku: str, name: str, price: str) -> None:
+    with _get_session() as session:
+        obj = session.query(Variant).get((product_id, sku))
+        if obj is None:
+            obj = Variant(product_id=product_id, sku=sku)
+            session.add(obj)
+        obj.name = name
+        obj.price = price
+        session.commit()
+
+
+def record_competitor(product_id: str, title: str, url: str, file_path: str, status: str) -> None:
+    with _get_session() as session:
+        comp = Competitor(product_id=product_id, title=title, url=url, file_path=file_path, status=status)
+        session.add(comp)
+        session.commit()
+
+
+def search_products(name: str) -> List[Tuple[str, str, str, str]]:
+    with _get_session() as session:
+        results = (
+            session.query(Product)
+            .filter(Product.name.like(f"%{name}%"))
+            .all()
         )
-        """
-    )
-    cur.execute(
-        """
-        CREATE TABLE IF NOT EXISTS variants (
-            product_id TEXT,
-            sku TEXT,
-            name TEXT,
-            price TEXT,
-            PRIMARY KEY (product_id, sku),
-            FOREIGN KEY(product_id) REFERENCES products(product_id)
-        )
-        """
-    )
-    cur.execute(
-        """
-        CREATE TABLE IF NOT EXISTS competitors (
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            product_id TEXT,
-            title TEXT,
-            url TEXT,
-            file_path TEXT,
-            status TEXT,
-            FOREIGN KEY(product_id) REFERENCES products(product_id)
-        )
-        """
-    )
-    conn.commit()
-    conn.close()
+        return [(p.product_id, p.name, p.sku, p.price) for p in results]
 
-
-def upsert_product(product_id, name, sku, price, dossier, base_dir=None):
-    path = db_path(base_dir)
-    conn = sqlite3.connect(path)
-    cur = conn.cursor()
-    cur.execute(
-        """
-        INSERT INTO products(product_id, name, sku, price, dossier)
-        VALUES (?, ?, ?, ?, ?)
-        ON CONFLICT(product_id) DO UPDATE SET
-            name=excluded.name,
-            sku=excluded.sku,
-            price=excluded.price,
-            dossier=excluded.dossier
-        """,
-        (product_id, name, sku, price, dossier),
-    )
-    conn.commit()
-    conn.close()
-
-
-def upsert_variant(product_id, sku, name, price, base_dir=None):
-    path = db_path(base_dir)
-    conn = sqlite3.connect(path)
-    cur = conn.cursor()
-    cur.execute(
-        """
-        INSERT INTO variants(product_id, sku, name, price)
-        VALUES (?, ?, ?, ?)
-        ON CONFLICT(product_id, sku) DO UPDATE SET
-            name=excluded.name,
-            price=excluded.price
-        """,
-        (product_id, sku, name, price),
-    )
-    conn.commit()
-    conn.close()
-
-
-def record_competitor(product_id, title, url, file_path, status, base_dir=None):
-    path = db_path(base_dir)
-    conn = sqlite3.connect(path)
-    cur = conn.cursor()
-    cur.execute(
-        """
-        INSERT INTO competitors(product_id, title, url, file_path, status)
-        VALUES (?, ?, ?, ?, ?)
-        """,
-        (product_id, title, url, file_path, status),
-    )
-    conn.commit()
-    conn.close()
-
-
-def search_products(name, base_dir=None):
-    path = db_path(base_dir)
-    conn = sqlite3.connect(path)
-    cur = conn.cursor()
-    cur.execute("SELECT product_id, name, sku, price FROM products WHERE name LIKE ?", (f"%{name}%",))
-    rows = cur.fetchall()
-    conn.close()
-    return rows

--- a/tests/test_storage_orm.py
+++ b/tests/test_storage_orm.py
@@ -1,0 +1,18 @@
+import os
+from pathlib import Path
+
+import db
+import storage
+
+
+def test_upsert_and_search(tmp_path):
+    path = tmp_path / "test.db"
+    db.init_engine(path)
+    storage.init_db()
+
+    storage.upsert_product("1", "Test Shoe", "SKU1", "10", "folder")
+    storage.upsert_variant("1", "SKU1-V", "Variant", "9")
+    storage.record_competitor("1", "title", "http://x", "/f", "ok")
+
+    results = storage.search_products("Test")
+    assert results == [("1", "Test Shoe", "SKU1", "10")]


### PR DESCRIPTION
## Summary
- depend on SQLAlchemy
- define ORM models in `db/models.py` and session helpers
- reimplement `storage.py` using SQLAlchemy
- initialise engine from `ScraperCore`
- add SQL-based accounting storage
- test ORM storage

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842da7fb8c483309791d899cd75305c