### PR TITLE
Launch Flask server with GUI

### DIFF
--- a/Application.py
+++ b/Application.py
@@ -1,4 +1,5 @@
 import sys
+import subprocess
 import logger_setup  # noqa: F401  # configure logging
 from PySide6.QtWidgets import QApplication
 from ui.main_window import DashboardWindow
@@ -10,11 +11,13 @@ import scheduler
 def main():
     db.init_engine(storage.db_path())
     storage.init_db()
+    flask_proc = subprocess.Popen(["python", "flask_server.py"])
 
     app = QApplication(sys.argv)
     window = DashboardWindow()
     scheduler.set_notify_callback(window.show_notification)
     window.show()
+    app.aboutToQuit.connect(flask_proc.terminate)
     sys.exit(app.exec())
 
 

--- a/README_en.md
+++ b/README_en.md
@@ -206,14 +206,8 @@ ID | Variante | URL concurrent | Nom image          | Lien WordPress
 A1 | Rouge    | https://...    | a1-rouge-face.webp | https://monsite.com/wp-content/uploads/2025/06/a1-rouge-face.webp
 ```
 
-### Flask Server (Optional)
-`flask_server.py` exposes a small HTTP API for uploading and listing product files. Start it separately if needed:
-
-```bash
-python flask_server.py
-```
-
-The server listens on port `5000` by default.
+### Flask Server API
+`flask_server.py` exposes a small HTTP API for uploading and listing product files. The server is started automatically when launching the GUI with `Application.py` and listens on port `5000` by default.
 
 ## Logging
 All console output is also written to `logs/app.log` at the repository root. The

--- a/ui/base_window.py
+++ b/ui/base_window.py
@@ -660,9 +660,6 @@ class MainWindow(QMainWindow):
         layout.setContentsMargins(20, 20, 20, 20)
         layout.setSpacing(15)
 
-        self.btn_activate_flask = RoundButton("Activer Flask")
-        self.btn_activate_flask.clicked.connect(self._on_activate_flask)
-        layout.addWidget(self.btn_activate_flask)
         self.btn_stop_api = RoundButton("Arrêter", color="secondary")
         self.btn_stop_api.clicked.connect(self._stop_worker)
         layout.addWidget(self.btn_stop_api)
@@ -846,14 +843,6 @@ class MainWindow(QMainWindow):
 
         self._run_async(self.scraper_tab, task, console_output=self.console_output_scraper)
 
-    def _on_activate_flask(self):
-        folder = self.input_fiche_folder.text() or self.scraper.save_directory
-        batch = self.spin_batch.value()
-
-        def task(progress_callback, should_stop):
-            self.scraper.run_flask_server(folder, batch)
-
-        self._run_async(None, task, console_output=self.console_output_scraper)
 
     def _on_upload_fiche(self):
         folder = self.input_fiche_folder.text()


### PR DESCRIPTION
## Summary
- start the Flask API automatically when opening the GUI
- remove the obsolete "Activer Flask" button
- document the automatic API server start

## Testing
- `pip install -e .`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842f93b445c8330add5f92cccbba6c5