### PR TITLE
Add module directories and README docs

### DIFF
--- a/c_modules/README.md
+++ b/c_modules/README.md
@@ -1,0 +1,16 @@
+# Modules C/C++
+
+Placez ici les bibliothèques ou programmes en C/C++.
+Chaque sous-répertoire peut contenir un `Makefile` ou un fichier CMake.
+
+## Construire et lancer
+```bash
+make # ou cmake -B build && cmake --build build
+./<programme>
+```
+
+## Tests
+Documentez la procédure de test (par ex. `make test`).
+
+## API/Interface
+Précisez les headers ou binaires exposés par votre module.

--- a/go_modules/README.md
+++ b/go_modules/README.md
@@ -1,0 +1,18 @@
+# Modules Go
+
+Ce dossier accueille les projets écrits en Go.
+Chaque sous-répertoire doit contenir son propre `go.mod`.
+
+## Construire et lancer
+```bash
+go build
+./<nom_du_binaire>
+```
+
+## Tests
+```bash
+go test ./...
+```
+
+## API/Interface
+Décrivez les packages ou commandes disponibles pour chaque module.

--- a/js_modules/README.md
+++ b/js_modules/README.md
@@ -1,0 +1,19 @@
+# Node.js Modules
+
+Ce dossier contient les sous-modules écrits en Node.js ou TypeScript.
+Chaque sous-répertoire doit être un paquet autonome avec son propre `package.json`.
+
+## Construire et lancer
+```bash
+npm install
+npm run build
+node dist/index.js # ou la commande spécifique au module
+```
+
+## Tests
+```bash
+npm test
+```
+
+## API/Interface
+Documentez ici les commandes CLI ou les endpoints exposés par votre module.

--- a/python_packages/README.md
+++ b/python_packages/README.md
@@ -1,0 +1,17 @@
+# Modules Python internes
+
+Les packages Python développés pour ce projet doivent être placés ici.
+Chaque sous-dossier doit contenir un `setup.cfg` ou un `pyproject.toml`.
+
+## Construire et lancer
+```bash
+pip install -e .
+```
+
+## Tests
+```bash
+pytest
+```
+
+## API/Interface
+Documentez les modules ou scripts exposés dans chaque package.

--- a/rust_modules/README.md
+++ b/rust_modules/README.md
@@ -1,0 +1,17 @@
+# Modules Rust
+
+Rangez ici les sous-projets développés en Rust. Chaque module doit comporter un `Cargo.toml`.
+
+## Construire et lancer
+```bash
+cargo build --release
+./target/release/<nom_du_binaire>
+```
+
+## Tests
+```bash
+cargo test
+```
+
+## API/Interface
+Indiquez les bibliothèques ou binaires fournis et leurs options principales.


### PR DESCRIPTION
## Summary
- scaffold future language-specific modules with dedicated folders
- add README files outlining build/test commands and API documentation guidelines for each language

## Testing
- `pip install -q -r requirements.txt`
- `pip install -q pytest`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'accounting')*

------
https://chatgpt.com/codex/tasks/task_e_6842ff47cf7c8330b52ff593d35efd22