### PR TITLE
Update README with server info

### DIFF
--- a/README_en.md
+++ b/README_en.md
@@ -116,7 +116,18 @@ automatically at runtime.
 python Application.py
 ```
 
-This starts the PySide6 interface for scraping WooCommerce products.
+This starts the PySide6 interface for scraping WooCommerce products and also
+launches `flask_server.py` in the background. The API listens on port `5000`
+and automatically stops when you close the GUI.
+
+To run the server manually you can execute:
+
+```bash
+python flask_server.py
+```
+
+Press `Ctrl+C` to stop the service or terminate the process from your
+task manager.
 
 Use the "Mode sans t\u00eate (headless)" checkbox in the settings page to run Chrome without opening a visible window.
 
@@ -213,6 +224,11 @@ A1 | Rouge    | https://...    | a1-rouge-face.webp | https://monsite.com/wp-con
 All console output is also written to `logs/app.log` at the repository root. The
 file rotates automatically when it reaches about 1 MB. Errors coming from the
 `accounting` package are additionally stored in `logs/compta_errors.log`.
+Monitor the log live with:
+
+```bash
+tail -f logs/app.log
+```
 
 ## Resuming a Scrape
 During scraping, progress is stored in `scraping_checkpoint.json` inside
@@ -296,6 +312,28 @@ argument:
 ```
 
 Ensure that Python and the console script are in the system `PATH`.
+
+## Node.js and Go Microservices
+
+Additional microservices can be implemented in the `js_modules` and
+`go_modules` directories. To start a Node.js service:
+
+```bash
+cd js_modules/<service>
+npm install
+npm start    # or: node dist/index.js
+```
+
+For a Go service:
+
+```bash
+cd go_modules/<service>
+go build
+./<service>
+```
+
+Stop the service with `Ctrl+C` and interact with its HTTP API using `curl` or
+from the main application.
 
 ## License
 This project is licensed under the MIT License. See the [LICENSE](LICENSE) file for details.

--- a/README_fr.md
+++ b/README_fr.md
@@ -47,3 +47,48 @@ Lancez l'interface PySide6 avec :
 python Application.py
 ```
 Elle permet d'effectuer le scraping, l'optimisation des images et de consulter les rapports.
+
+### D\u00e9marrage du serveur Flask
+`Application.py` (ou `app.py` selon la version) lance automatiquement
+`flask_server.py` en arri\u00e8re-plan sur le port `5000`. Le serveur se termine
+quand l'interface se ferme.
+
+Pour d\u00e9marrer le serveur manuellement :
+
+```bash
+python flask_server.py
+```
+
+Arr\u00eatez-le avec `Ctrl+C` ou en fermant le processus.
+
+### Surveillance des logs
+Tous les messages sont enregistr\u00e9s dans `logs/app.log`. Utilisez :
+
+```bash
+tail -f logs/app.log
+```
+
+pour suivre l'activit\u00e9 en temps r\u00e9el.
+
+## Microservices Node.js / Go
+Les microservices suppl\u00e9mentaires se trouvent dans `js_modules` et
+`go_modules`.
+
+Pour lancer un service Node.js :
+
+```bash
+cd js_modules/mon_service
+npm install
+npm start    # ou node dist/index.js
+```
+
+Pour un service Go :
+
+```bash
+cd go_modules/mon_service
+go build
+./mon_service
+```
+
+Interrompez-les avec `Ctrl+C` et interagissez via leur API HTTP avec `curl` ou
+l'application principale.


### PR DESCRIPTION
## Summary
- document how Application.py starts the Flask server
- show how to start/stop the service manually
- add log monitoring instructions
- add basic instructions for Node.js and Go microservices

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'db')*

------
https://chatgpt.com/codex/tasks/task_e_68430307f03c833084fbac5071be6dc8