### PR TITLE
Add native module docs

### DIFF
--- a/README_en.md
+++ b/README_en.md
@@ -335,5 +335,38 @@ go build
 Stop the service with `Ctrl+C` and interact with its HTTP API using `curl` or
 from the main application.
 
+## Native Modules (C/Rust)
+
+Sample native libraries live in the `c_modules` and `rust_modules` folders. The C example under `c_modules/hello` exposes a simple `add` function. Build it with:
+
+```bash
+cd c_modules/hello
+make
+```
+
+This creates `libhello.so` which can be loaded with `ctypes`:
+
+```python
+from ctypes import CDLL, c_int
+lib = CDLL("c_modules/hello/libhello.so")
+print(lib.add(c_int(2), c_int(3)))  # 5
+```
+
+The Rust counterpart `rust_modules/hello` builds a shared library exporting a `multiply` function:
+
+```bash
+cd rust_modules/hello
+cargo build --release
+```
+
+Use `ctypes` in the same way:
+
+```python
+from ctypes import CDLL
+lib = CDLL("rust_modules/hello/target/release/libhello.so")
+print(lib.multiply(4, 5))  # 20
+```
+
+
 ## License
 This project is licensed under the MIT License. See the [LICENSE](LICENSE) file for details.

--- a/README_fr.md
+++ b/README_fr.md
@@ -92,3 +92,35 @@ go build
 
 Interrompez-les avec `Ctrl+C` et interagissez via leur API HTTP avec `curl` ou
 l'application principale.
+## Modules natifs (C/Rust)
+
+Des exemples simples se trouvent dans les dossiers `c_modules` et `rust_modules`. Celui de `c_modules/hello` expose une fonction `add`. Compilez-le avec :
+
+```bash
+cd c_modules/hello
+make
+```
+
+Le fichier `libhello.so` peut être chargé depuis Python grâce à `ctypes` :
+
+```python
+from ctypes import CDLL, c_int
+lib = CDLL("c_modules/hello/libhello.so")
+print(lib.add(c_int(2), c_int(3)))  # 5
+```
+
+Le projet `rust_modules/hello` fournit une fonction `multiply`. Compilez-le :
+
+```bash
+cd rust_modules/hello
+cargo build --release
+```
+
+Le fichier compilé `target/release/libhello.so` se charge de la même manière :
+
+```python
+from ctypes import CDLL
+lib = CDLL("rust_modules/hello/target/release/libhello.so")
+print(lib.multiply(4, 5))  # 20
+```
+

--- a/c_modules/hello/Makefile
+++ b/c_modules/hello/Makefile
@@ -1,0 +1,7 @@
+all: libhello.so
+
+libhello.so: hello.c
+	gcc -shared -fPIC hello.c -o libhello.so
+
+clean:
+	rm -f libhello.so

--- a/c_modules/hello/hello.c
+++ b/c_modules/hello/hello.c
@@ -1,0 +1,5 @@
+#include <stdio.h>
+
+int add(int a, int b) {
+    return a + b;
+}

--- a/rust_modules/hello/Cargo.toml
+++ b/rust_modules/hello/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "hello"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]

--- a/rust_modules/hello/src/lib.rs
+++ b/rust_modules/hello/src/lib.rs
@@ -1,0 +1,4 @@
+#[no_mangle]
+pub extern "C" fn multiply(a: i32, b: i32) -> i32 {
+    a * b
+}


### PR DESCRIPTION
## Summary
- add simple C and Rust examples
- explain how to build native modules in README_en.md and README_fr.md

## Testing
- `pytest -k nonexistent_test_pattern` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6843043d35e0833097c9632a9c740c01