### PR TITLE
Fix scheduler DB initialization

### DIFF
--- a/Application.py
+++ b/Application.py
@@ -11,6 +11,7 @@ import scheduler
 def main():
     db.init_engine(storage.db_path())
     storage.init_db()
+    scheduler.init_scheduler()
     flask_proc = subprocess.Popen(["python", "flask_server.py"])
 
     app = QApplication(sys.argv)

--- a/scheduler.py
+++ b/scheduler.py
@@ -106,5 +106,10 @@ def toggle_task(task_id: int) -> None:
         session.commit()
 
 
-scheduler.start()
-load_tasks()
+def init_scheduler() -> None:
+    """Start the background scheduler and load persisted tasks."""
+    if scheduler.running:
+        return
+    scheduler.start()
+    load_tasks()
+


### PR DESCRIPTION
## Summary
- initialize scheduler only after DB engine is ready

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843356df00483309fc59ef275a199e2