### PR TITLE
Fix SQLite engine initialization

### DIFF
--- a/README_en.md
+++ b/README_en.md
@@ -84,8 +84,9 @@ IMAGE_NAME_PATTERN = "{id}:{variant}-{name}.webp"
 You can edit this file directly or use the **Settings** page in the GUI which
 updates it automatically. Each key is described below:
 
-* `BASE_DIR` – directory used to store generated files. Defaults to the folder
-  containing `config.py`.
+* `BASE_DIR` – directory used to store generated files including
+  `scraper.db`. Defaults to the folder containing `config.py`. If the
+  directory does not exist it will be created automatically at startup.
 * `CHROME_DRIVER_PATH` – optional path to a `chromedriver` executable (useful
   without internet access)
 * `CHROME_BINARY_PATH` – optional path to the Chrome binary

--- a/README_fr.md
+++ b/README_fr.md
@@ -40,6 +40,9 @@ pytest
 
 ### Paramétrage
 Les chemins sont stockés dans `config.toml` à la racine du dépôt. S'il est absent, un fichier par défaut est créé.
+Le fichier SQLite est situé par défaut dans `BASE_DIR/scraper.db`. Si
+`BASE_DIR` pointe vers un dossier inexistant, il sera créé automatiquement au
+prochain démarrage.
 
 ### Utilisation de l'application
 Lancez l'interface PySide6 avec :

--- a/db/__init__.py
+++ b/db/__init__.py
@@ -11,8 +11,16 @@ SessionLocal = sessionmaker(autocommit=False, autoflush=False)
 
 
 def init_engine(path: str | Path):
-    """Initialise the global engine and session factory."""
+    """Initialise the global engine and session factory.
+
+    Ensures the parent directory exists before opening the SQLite
+    database so that ``create_engine`` does not fail if the file or its
+    folder is missing.
+    """
     global engine, SessionLocal
-    engine = create_engine(f"sqlite:///{path}")
+    db_path = Path(path)
+    if db_path.parent and not db_path.parent.exists():
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+    engine = create_engine(f"sqlite:///{db_path}")
     SessionLocal.configure(bind=engine)
     return engine


### PR DESCRIPTION
## Summary
- ensure SQLite parent folder exists when creating engine
- document automatic database creation in README (EN/FR)

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'db')*

------
https://chatgpt.com/codex/tasks/task_e_68433791273c8330a6ed56e4c1bc2b27