### PR TITLE
Add collapsible sidebar sections

### DIFF
--- a/ui/__init__.py
+++ b/ui/__init__.py
@@ -1,1 +1,10 @@
-from .components import RoundButton, Sidebar, Card, Toast, show_success, show_error
+from .components import (
+    RoundButton,
+    Sidebar,
+    Card,
+    Toast,
+    CollapsibleSection,
+    global_signals,
+    show_success,
+    show_error,
+)


### PR DESCRIPTION
## Summary
- add `CollapsibleSection` widget in `ui.components`
- expose new widget and global signal in `ui/__init__`
- replace old sidebar with collapsible sections in `DashboardWindow`
- update responsive handling and add global collapsing on mouse clicks
- install package and run tests

## Testing
- `pip install -e .`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684341559f9c8330b2d26bfbf520daf8