### PR TITLE
Fix test imports by adjusting PYTHONPATH

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import os
+import sys
+
+# Add project root to PYTHONPATH for tests
+PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)


### PR DESCRIPTION
## Summary
- ensure tests can import project modules by adding `tests/conftest.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843416e8cf4833080073c114d819a07