### PR TITLE
Add sidebar icons and responsive doc

### DIFF
--- a/README_fr.md
+++ b/README_fr.md
@@ -50,6 +50,8 @@ Lancez l'interface PySide6 avec :
 python Application.py
 ```
 Elle permet d'effectuer le scraping, l'optimisation des images et de consulter les rapports.
+Chaque option de la barre latérale affiche désormais une icône (icône Qt standard ou chargée depuis `ui/resources`).
+La barre se rétracte automatiquement sur les petits écrans et peut être agrandie manuellement.
 
 ### D\u00e9marrage du serveur Flask
 L'API n'est plus d\u00e9marr\u00e9e automatiquement. Lancez-la via le bouton **D\u00e9marrer l'API**

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -137,29 +137,29 @@ class DashboardWindow(ResponsiveMixin, MainWindow):
 
         self.section_ecom = CollapsibleSection("🛒  E-commerce")
         ecommerce_items = [
-            ("Accueil", QStyle.SP_DesktopIcon),
-            ("Scraper", QStyle.SP_FileIcon),
-            ("Scraping d'image", QStyle.SP_DirIcon),
-            ("Scraping d'images avancé", QStyle.SP_DirIcon),
-            ("Images avancées", QStyle.SP_DirIcon),
-            ("Sélecteur visuel", QStyle.SP_DialogOpenButton),
-            ("Optimiseur d'images", QStyle.SP_ComputerIcon),
-            ("Rapports", QStyle.SP_FileDialogInfoView),
-            ("API Flask", QStyle.SP_BrowserReload),
-            ("Tâches planifiées", QStyle.SP_FileDialogListView),
+            ("Accueil", self.style().standardIcon(QStyle.SP_DesktopIcon)),
+            ("Scraper", self.style().standardIcon(QStyle.SP_FileIcon)),
+            ("Scraping d'image", self.style().standardIcon(QStyle.SP_DirIcon)),
+            ("Scraping d'images avancé", self.style().standardIcon(QStyle.SP_DirIcon)),
+            ("Images avancées", self.style().standardIcon(QStyle.SP_DirIcon)),
+            ("Sélecteur visuel", self.style().standardIcon(QStyle.SP_DialogOpenButton)),
+            ("Optimiseur d'images", self.style().standardIcon(QStyle.SP_ComputerIcon)),
+            ("Rapports", QIcon('ui/resources/reports.svg')),
+            ("API Flask", self.style().standardIcon(QStyle.SP_BrowserReload)),
+            ("Tâches planifiées", self.style().standardIcon(QStyle.SP_FileDialogListView)),
         ]
         for text, icon in ecommerce_items:
-            self.section_ecom.add_item(text, self.style().standardIcon(icon))
+            self.section_ecom.add_item(text, icon)
 
         self.section_compta = CollapsibleSection("📒  Comptabilité")
         accounting_items = [
-            ("Journal", QStyle.SP_FileDialogInfoView),
-            ("Comptabilité", QStyle.SP_FileDialogContentsView),
-            ("Paramètres", QStyle.SP_FileDialogDetailedView),
-            ("Aide compta", QStyle.SP_DialogHelpButton),
+            ("Journal", self.style().standardIcon(QStyle.SP_FileDialogInfoView)),
+            ("Comptabilité", QIcon('ui/resources/accounting.svg')),
+            ("Paramètres", self.style().standardIcon(QStyle.SP_FileDialogDetailedView)),
+            ("Aide compta", QIcon('ui/resources/help.svg')),
         ]
         for text, icon in accounting_items:
-            self.section_compta.add_item(text, self.style().standardIcon(icon))
+            self.section_compta.add_item(text, icon)
 
         for sec in [self.section_ecom, self.section_compta]:
             sec.item_clicked.connect(self._on_sidebar_row_changed)

--- a/ui/resources/accounting.svg
+++ b/ui/resources/accounting.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16">
+  <path d="M3 2h10v12H3z" fill="none" stroke="black"/>
+  <path d="M6 2v12M10 2v12" stroke="black"/>
+</svg>

--- a/ui/resources/help.svg
+++ b/ui/resources/help.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16">
+  <circle cx="8" cy="8" r="7" fill="none" stroke="black"/>
+  <path d="M8 5a2 2 0 0 1 2 2c0 1.5-2 2-2 3" fill="none" stroke="black"/>
+  <circle cx="8" cy="11" r="1" fill="black"/>
+</svg>

--- a/ui/resources/reports.svg
+++ b/ui/resources/reports.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16">
+  <rect x="2" y="2" width="12" height="12" fill="none" stroke="black"/>
+  <path d="M4 6h8M4 9h8M4 12h8" stroke="black"/>
+</svg>


### PR DESCRIPTION
## Summary
- assign icons to sidebar items in `DashboardWindow` using Qt standard icons or custom SVGs
- store icons in lists `ecommerce_items` and `accounting_items`
- document sidebar icons and responsive behaviour in French README
- include simple SVG icon files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68434675b35883309ce49d6342bf9c24