### PR TITLE
Add lightweight CSS detection module

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,94 @@ Launch the application with:
 ```bash
 python Application.py
 ```
+
+---
+
+## Détection CSS avec IA légère
+
+✨ RÉCAPITULATIF COMPLET – Mise en place de ton système intelligent pour détection CSS avec IA légère
+
+---
+
+🎯 Objectif général :
+Créer un outil intelligent capable de :
+- Recevoir du HTML
+- Comprendre une question (ex : "Je veux le lien" / "Donne-moi le titre")
+- Générer le meilleur sélecteur CSS
+- Fonctionner hors-ligne, léger, sans dépendre d’un navigateur (pas Selenium)
+- Utiliser une IA embarquée légère (DistilBERT) pour simuler un mini cerveau
+
+---
+
+🧱 Architecture à 2 composants :
+
+1. **cerveau.py** – Le cerveau IA
+   - Chargera DistilBERT ou un modèle NLP léger (ex : zero-shot classifier)
+   - Comprend la question et déduit la cible à extraire dans le HTML
+   - Retourne un mot-clé cible (ex : "lien" → chercher `<a>`, "titre" → chercher `h1`/`h2`/`h3`…)
+
+2. **detecteur.py** – Le moteur d’analyse
+   - Reçoit un extrait HTML et une demande (ex : "je veux le lien")
+   - Envoie la question au cerveau
+   - Extrait les balises ou classes en fonction de la réponse du cerveau
+   - Retourne un sélecteur CSS stable et optimisé
+
+---
+
+📁 Structure du projet :
+
+```
+projet-scrap/
+├── cerveau.py            # IA NLP avec DistilBERT
+├── detecteur.py          # Détection + extraction + interaction
+├── requirements.txt      # Liste des libs nécessaires
+└── samples/              # (Optionnel) dossiers de tests HTML
+```
+
+---
+
+🛠️ Préparation et installation :
+
+1. Créer un environnement virtuel (recommandé) :
+   ```bash
+   python -m venv venv
+   source venv/bin/activate  # (ou venv\Scripts\activate sous Windows)
+   ```
+2. Installer les bibliothèques :
+   ```bash
+   pip install torch transformers beautifulsoup4
+   ```
+3. Créer ton fichier `requirements.txt` :
+   ```
+   torch
+   transformers
+   beautifulsoup4
+   ```
+
+---
+
+🧠 Exemple de pipeline de communication :
+
+```python
+# detecteur.py
+from cerveau import analyser_requete
+
+type_cible = analyser_requete("je veux le lien")
+# Retourne 'lien' ou 'titre'
+# Puis détecte automatiquement <a> ou <h2> dans le HTML fourni
+```
+
+---
+
+💡 Avantages de ce système :
+
+| 🧠 IA Compréhensive | ⚙️ Léger et modulaire | 🔌 Fonctionne hors-ligne | 📚 Évolutif facilement |
+|---------------------|-----------------------|---------------------------|-------------------------|
+| Tu poses une question librement | Chaque module peut évoluer indépendamment | Pas besoin de navigateur | Tu peux lui apprendre de nouveaux labels ou comportements |
+
+---
+
+❓ Et ensuite ?
+- 💾 Générer les deux scripts (`cerveau.py` + `detecteur.py`) prêts à l’emploi ?
+- 📂 Fournir un dossier complet zippé avec l’environnement prêt ?
+- 🧠 Montrer comment ajouter de nouveaux types de questions intelligentes ?

--- a/projet-scrap/cerveau.py
+++ b/projet-scrap/cerveau.py
@@ -1,0 +1,19 @@
+from transformers import pipeline
+
+_classifier = None
+
+
+def _get_classifier():
+    global _classifier
+    if _classifier is None:
+        # DistilBERT zero-shot-classification pipeline
+        _classifier = pipeline("zero-shot-classification", model="distilbert-base-uncased")
+    return _classifier
+
+
+def analyser_requete(question: str) -> str:
+    """Analyse la question utilisateur et renvoie le type de cible."""
+    classifier = _get_classifier()
+    labels = ["lien", "titre"]
+    result = classifier(question, labels)
+    return result["labels"][0]

--- a/projet-scrap/detecteur.py
+++ b/projet-scrap/detecteur.py
@@ -1,0 +1,28 @@
+from bs4 import BeautifulSoup
+from cerveau import analyser_requete
+
+
+def generer_selecteur(tag) -> str:
+    """Retourne un sélecteur CSS simple pour un tag BeautifulSoup."""
+    if tag.get("id"):
+        return f"#{tag['id']}"
+    if tag.get("class"):
+        return f"{tag.name}.{' '.join(tag.get('class'))}"
+    return tag.name
+
+
+def detecter_selecteur(html: str, question: str) -> str:
+    """Détecte l'élément correspondant à la question et renvoie un sélecteur."""
+    type_cible = analyser_requete(question)
+    soup = BeautifulSoup(html, "html.parser")
+
+    if type_cible == "lien":
+        element = soup.find("a")
+    elif type_cible == "titre":
+        element = soup.find(["h1", "h2", "h3"])
+    else:
+        element = None
+
+    if not element:
+        return ""
+    return generer_selecteur(element)

--- a/projet-scrap/requirements.txt
+++ b/projet-scrap/requirements.txt
@@ -1,0 +1,3 @@
+torch
+transformers
+beautifulsoup4

--- a/projet-scrap/samples/example.html
+++ b/projet-scrap/samples/example.html
@@ -1,0 +1,7 @@
+<html>
+<head><title>Test</title></head>
+<body>
+<h1 id="main-title">Bienvenue</h1>
+<a href="/page">Lien</a>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add docs describing lightweight CSS detection AI
- implement `projet-scrap` prototype with `cerveau.py` and `detecteur.py`
- include minimal requirements and sample HTML

## Testing
- `pip install .[test]`
- `playwright install` *(fails: Domain forbidden)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684ad1d084c48330a3400cee1592543c